### PR TITLE
Limit when we rebuild the Docker image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,11 +7,9 @@ name: Docker
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "production" ]
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
-  pull_request:
-    branches: [ "main" ]
 
 env:
   # Use docker.io for Docker Hub if empty


### PR DESCRIPTION
Currently we're rebuilding and publishing a new Docker image anytime we submit a PR against main, or push to it. We don't really need to use up our GitHub Action minutes on that. This change should limit when we run the rebuild to pushes against the new production branch (and not on PRs).