### PR TITLE
Feature/19 enable logging

### DIFF
--- a/libriscan/biblios/views.py
+++ b/libriscan/biblios/views.py
@@ -1,7 +1,11 @@
+import logging
+
 from django.shortcuts import render
 from django.views.generic import ListView, DetailView
 
 from .models import Organization, Consortium
+
+logger = logging.getLogger(__name__)
 
 def index(request):
     orgs = Organization.objects.all()

--- a/libriscan/libriscan/settings.py
+++ b/libriscan/libriscan/settings.py
@@ -140,6 +140,8 @@ LOGGING = {
         "file": {
             "level": log_level,
             "class": "logging.handlers.RotatingFileHandler",
+            "maxBytes": 5242880,            
+            "backupCount": 10,
             "filename": LOCAL_DIR / "logs/libriscan.log",
             "formatter": "standard"
         },


### PR DESCRIPTION
Closes #19 
- Checks optional env var DJANGO_LOG_LEVEL for level, defaults to INFO
- Writes detailed log messages to a rotating log file in the Docker volume
- Should rotate logs every 5MB and keep 10 old files
- Streams less detailed messages to stdout (which Docker logs will pick up)
- Also added a new LOCAL_DIR var that points to the persistent Docker volume
