### PR TITLE
Feature/57 Upload Image

### DIFF
--- a/libriscan/biblios/forms.py
+++ b/libriscan/biblios/forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.conf import settings
 from django.contrib.auth.forms import UserCreationForm, UserChangeForm
 
 from biblios.models import User, Document, Page
@@ -27,3 +28,23 @@ class PageForm(forms.ModelForm):
     class Meta:
         model = Page
         fields = ("document", "number", "image")
+
+
+class FilePondUploadForm(forms.Form):
+    image = forms.ImageField()
+
+    def clean_image(self):
+        image = self.cleaned_data.get('image')
+        if not image:
+            raise forms.ValidationError('No file was submitted.')
+
+        # Check file type
+        if image.content_type not in getattr(settings, 'ALLOWED_UPLOAD_TYPES', []):
+            raise forms.ValidationError('Invalid file type. Please upload TIFF, JPEG, or PNG files only.')
+
+        # Check file size
+        max_size = getattr(settings, 'MAX_UPLOAD_SIZE', 5 * 1024 * 1024)
+        if image.size > max_size:
+            raise forms.ValidationError('File size exceeds limit. Please upload a smaller file.')
+
+        return image

--- a/libriscan/biblios/templates/biblios/base.html
+++ b/libriscan/biblios/templates/biblios/base.html
@@ -11,6 +11,12 @@
   <link href="https://cdn.jsdelivr.net/npm/daisyui@5" rel="stylesheet" type="text/css" />
   <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
   
+  <!-- FilePond Dependencies -->
+  <link href="https://unpkg.com/filepond/dist/filepond.css" rel="stylesheet">
+  <link href="https://unpkg.com/filepond-plugin-image-preview/dist/filepond-plugin-image-preview.css" rel="stylesheet">
+  <script src="https://unpkg.com/filepond-plugin-image-preview/dist/filepond-plugin-image-preview.js"></script>
+  <script src="https://unpkg.com/filepond/dist/filepond.js"></script>
+  
   <!-- Theme Toggle Script -->
   <script>
     function toggleTheme() {

--- a/libriscan/biblios/templates/biblios/components/forms/file_upload.html
+++ b/libriscan/biblios/templates/biblios/components/forms/file_upload.html
@@ -1,40 +1,114 @@
 {% load static %}
 
+<style>
+/* Prevent drag events outside upload area */
+body * {
+  pointer-events: auto;
+}
+
+.upload-area {
+  pointer-events: none;
+}
+
+.upload-area .filepond--root,
+.upload-area .border-2 {
+  pointer-events: auto;
+}
+</style>
+
 <div class="card bg-base-100 shadow-sm h-full">
-    <div class="card-body">
-      <h2 class="card-title text-2xl mb-6">Quick Text Recognition</h2>
-      
-      <!-- File Upload Area -->
-      <div class="upload-area w-full">
-        <div class="border-2 border-dashed border-base-300 rounded-lg p-12 text-center hover:border-primary transition-colors cursor-pointer"
-             hx-post="/upload"
-             hx-trigger="dragover dragenter"
-             hx-swap="none">
-          <!-- Upload Icon -->
-          <!-- https://heroicons.com/ -->
-          <div class="flex justify-center mb-4">
-            <svg xmlns="http://www.w3.org/2000/svg" class="h-12 w-12 text-base-content opacity-50" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12" />
-            </svg>
-          </div>
-          
-          <!-- Upload Text -->
-          <div class="space-y-2">
-            <p class="text-lg font-semibold">Upload Image</p>
-            <p class="text-base-content opacity-60">Drag and drop files here or browse files</p>
-          </div>
+  <div class="card-body">
+    <h2 class="card-title text-2xl mb-6">Quick Text Recognition</h2>
+    
+    <!-- File Upload Area -->
+    <div class="upload-area w-full">
+      <!-- FilePond Input -->
+      <input type="file" 
+             class="filepond"
+             name="image"
+             accept="image/tiff,image/jpeg,image/png"
+             data-max-file-size="5MB">
 
-          <!-- Hidden File Input -->
-          <input type="file" 
-                 class="hidden" 
-                 accept="image/*"
-                 hx-post="/upload"
-                 hx-trigger="change"
-                 hx-target="#upload-status">
-        </div>
-
-        <!-- Upload Status -->
-        <div id="upload-status" class="mt-4"></div>
-      </div>
+             <!-- Upload Button -->
+             <button id="uploadBtn" 
+             class="btn btn-primary mt-4 w-full"
+             disabled>
+             Upload
+            </button>
     </div>
+  </div>
 </div>
+
+<!-- Drag Drop Prevention Script -->
+<script>
+  // Prevent default drag behavior outside upload area
+  document.addEventListener('dragover', (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+  }, false);
+
+  document.addEventListener('drop', (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+  }, false);
+</script>
+
+<!-- FilePond Initialization -->
+<script>
+  // Register the image preview plugin
+  FilePond.registerPlugin(FilePondPluginImagePreview);
+
+  // Get the input element
+  const inputElement = document.querySelector('input[type="file"].filepond');
+
+  // Create the FilePond instance
+  const pond = FilePond.create(inputElement, {
+    // Disable automatic upload
+    instantUpload: false,
+
+  // File validation using Django settings
+    acceptedFileTypes: ['image/tiff', 'image/jpeg', 'image/png'],
+    maxFileSize: '5MB',
+
+    // Style settings
+    styleButtonRemoveItemPosition: 'right',
+    stylePanelLayout: 'integrated',
+    styleLoadIndicatorPosition: 'center',
+    styleProgressIndicatorPosition: 'center',
+    styleButtonProcessItemPosition: 'center',
+    stylePanelAspectRatio: 1.25,
+    
+    // Image preview settings
+    allowImagePreview: true,
+    imageCropAspectRatio: '1:1',
+    
+    server: {
+      process: {
+        url: "{% url 'handle_upload' %}",
+        headers: {
+          'X-CSRFToken': document.querySelector('body').getAttribute('hx-headers').match(/"x-csrftoken":\s*"([^"]+)"/)[1]
+        }
+      }
+    },
+
+    onaddfile: (error, file) => {
+      if (error) {
+        console.error('File addition error:', error.body || error.message);
+        return;
+      }
+      document.getElementById('uploadBtn').disabled = false;
+    },
+    onprocessfile: (error, file) => {
+      if (error) {
+        console.error('Upload error:', error);
+      }
+      // Disable upload button after processing
+      document.getElementById('uploadBtn').disabled = true;
+    }
+  });
+
+  // Handle upload button click
+  document.getElementById('uploadBtn').addEventListener('click', () => {
+    pond.processFiles();
+  });
+</script>

--- a/libriscan/biblios/templates/biblios/components/forms/file_upload.html
+++ b/libriscan/biblios/templates/biblios/components/forms/file_upload.html
@@ -6,6 +6,12 @@ body * {
   pointer-events: auto;
 }
 
+/* Remove blocking credits */
+/* https://pqina.nl/filepond/docs/api/instance/properties/#disabling-credits */
+.filepond--credits {
+  display: none !important;
+}
+
 .upload-area {
   pointer-events: none;
 }
@@ -29,12 +35,19 @@ body * {
              accept="image/tiff,image/jpeg,image/png"
              data-max-file-size="5MB">
 
-             <!-- Upload Button -->
-             <button id="uploadBtn" 
-             class="btn btn-primary mt-4 w-full"
-             disabled>
-             Upload
-            </button>
+             <!-- Upload and Analyze Buttons Side by Side -->
+             <div class="flex gap-2 mt-4 w-full">
+               <button id="uploadBtn" 
+                 class="btn btn-primary flex-1 flex items-center gap-2"
+                 disabled>
+                 <span id="uploadBtnText">Upload</span>
+                 <span id="uploadSpinner" class="loading loading-bars loading-sm hidden"></span>
+               </button>
+               <button id="extractBtn" class="btn btn-accent flex-1 flex items-center gap-2" disabled>
+                 <span id="extractBtnText">Extract</span>
+                 <span id="extractSpinner" class="loading loading-bars loading-sm hidden"></span>
+               </button>
+             </div>
     </div>
   </div>
 </div>
@@ -99,16 +112,79 @@ body * {
       document.getElementById('uploadBtn').disabled = false;
     },
     onprocessfile: (error, file) => {
+      const btn = document.getElementById('uploadBtn');
+      const spinner = document.getElementById('uploadSpinner');
+      const btnText = document.getElementById('uploadBtnText');
+
+      // Hide loading state
+      spinner.classList.add('hidden');
+      btnText.textContent = 'Upload';
+      
       if (error) {
         console.error('Upload error:', error);
       }
       // Disable upload button after processing
-      document.getElementById('uploadBtn').disabled = true;
+      btn.disabled = true;
     }
   });
 
   // Handle upload button click
   document.getElementById('uploadBtn').addEventListener('click', () => {
+    const btn = document.getElementById('uploadBtn');
+    const spinner = document.getElementById('uploadSpinner');
+    const btnText = document.getElementById('uploadBtnText');
+    
+    // Show loading state
+    btn.disabled = true;
+    spinner.classList.remove('hidden');
+    btnText.textContent = 'Uploading...';
+    
     pond.processFiles();
+  });
+
+  // Enable Analyze button after upload
+  pond.on('processfile', (error, file) => {
+    if (!error) {
+      document.getElementById('extractBtn').disabled = false;
+    }
+  });
+
+  // Handle Extract button click
+  document.getElementById('extractBtn').addEventListener('click', function() {
+    const btn = this;
+    const spinner = document.getElementById('extractSpinner');
+    const btnText = document.getElementById('extractBtnText');
+
+    // Show loading state
+    btn.disabled = true;
+    spinner.classList.remove('hidden');
+    btnText.textContent = 'Extracting...';
+    
+    // Simulate extraction process
+    setTimeout(function() {
+      // Hide extract button spinner
+      spinner.classList.add('hidden');
+      btnText.textContent = 'Extract';
+      btn.disabled = false;
+      
+      // Hide right column temporarily
+      document.getElementById('rightColumn').style.display = 'none';
+      
+      // After a brief pause, show loading animation
+      setTimeout(function() {
+        document.getElementById('rightColumn').style.display = '';
+        document.getElementById('extractPrompt').style.display = 'none';
+        const loadingContainer = document.getElementById('loadingContainer');
+        loadingContainer.style.display = '';
+      }, 300); // Short delay for smooth transition
+
+      // After a delay, hide loading and show text display
+      setTimeout(function() {
+        loadingContainer.style.display = 'none';
+        const textDisplayContainer = document.getElementById('textDisplayContainer');
+        textDisplayContainer.style.display = '';
+        textDisplayContainer.scrollIntoView({ behavior: 'smooth' });
+      }, 1500); // Show loading animation for 1.5 seconds
+    }, 2000);
   });
 </script>

--- a/libriscan/biblios/templates/biblios/scan.html
+++ b/libriscan/biblios/templates/biblios/scan.html
@@ -11,8 +11,21 @@
     </div>
     
     <!-- Right Column: Text Display -->
-    <div class="w-full">
-      {% include "biblios/components/forms/text_display.html" %}
+    <div id="rightColumn" class="w-full">
+      <div id="extractPrompt" class="card bg-base-100 shadow-sm h-full">
+        <div class="card-body flex flex-col justify-center items-center h-full text-center p-6">
+          <h2 class="card-title text-2xl mb-4">No Text Extracted Yet</h2>
+          <p class="mb-4">Please upload an image containing text and click <span class="font-bold">Extract</span> after uploading for intelligent extraction.</p>
+        </div>  
+      </div>
+      <div id="loadingContainer" style="display:none;" class="card bg-base-100 shadow-sm h-full">
+        <div class="card-body flex flex-col justify-center items-center h-full text-center p-6">
+          <span class="loading loading-infinity loading-xl"></span>
+        </div>
+      </div>
+      <div id="textDisplayContainer" style="display:none;" class="w-full">
+        {% include "biblios/components/forms/text_display.html" %}
+      </div>
     </div>
   </div>
 </div>

--- a/libriscan/biblios/urls.py
+++ b/libriscan/biblios/urls.py
@@ -3,8 +3,14 @@ from django.urls import include, path
 from . import views
 
 urlpatterns = [
+    # Core pages
     path("", views.index, name="index"),
     path("scan/", views.scan, name="scan"),
+    
+    # File handling
+    path("upload/", views.handle_upload, name="handle_upload"),
+    
+    # Organization structure
     path("consortiums/<int:pk>/", views.ConsortiumDetail.as_view(), name="consortium"),
     path("organizations", views.organization_list, name="organization-list"),
     path(

--- a/libriscan/biblios/views.py
+++ b/libriscan/biblios/views.py
@@ -1,17 +1,21 @@
 import logging
-
-from django.http import HttpResponseRedirect
+import os
+from django.conf import settings
+from django.http import HttpResponseRedirect, HttpResponse
 from django.shortcuts import render
+from django.core.files.storage import default_storage
+from django.core.files.base import ContentFile
 from django.views.generic import ListView, DetailView
 from django.views.generic.edit import CreateView, DeleteView, UpdateView
 from django.views.decorators.http import require_http_methods
 from django.contrib.auth.decorators import login_required
 from django.urls import reverse_lazy
-
+from django.db import models
 
 from rules.contrib.views import AutoPermissionRequiredMixin, permission_required
 
 from .models import Organization, Consortium, Document, Collection, Series, Page
+from .forms import FilePondUploadForm
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +28,11 @@ def index(request):
 
 @login_required
 def scan(request):
-    return render(request, "biblios/scan.html")
+    context = {
+        "allowed_upload_types": settings.ALLOWED_UPLOAD_TYPES,
+        "max_upload_size": settings.MAX_UPLOAD_SIZE,
+    }
+    return render(request, "biblios/scan.html", context)
 
 
 class ConsortiumDetail(AutoPermissionRequiredMixin, DetailView):
@@ -148,6 +156,35 @@ class PageCreateView(AutoPermissionRequiredMixin, CreateView):
         form = PageForm(post, request.FILES)
 
         return self.form_valid(form) if form.is_valid() else self.form_invalid(form)
+
+
+@login_required
+@require_http_methods(["POST"])
+def handle_upload(request):
+    """Handle file uploads from FilePond."""
+    form = FilePondUploadForm(request.POST, request.FILES)
+    
+    if not form.is_valid():
+        error_msg = form.errors.get('image', ['Upload failed.'])[0]
+        return HttpResponse(error_msg, status=400)
+    
+    try:
+        upload_file = form.cleaned_data['image']
+        file_path = os.path.join('uploads', upload_file.name)
+        saved_path = default_storage.save(file_path, ContentFile(upload_file.read()))
+        
+        # Store file info in session
+        request.session['filepond_last_upload'] = {
+            'path': saved_path,
+            'name': upload_file.name,
+            'size': upload_file.size
+        }
+
+        return HttpResponse(saved_path)
+        
+    except OSError as e:
+        logger.error("File upload error: %s", e)
+        return HttpResponse('An error occurred while processing your file.', status=500)
 
 
 class PageDetail(AutoPermissionRequiredMixin, DetailView):

--- a/libriscan/libriscan/settings.py
+++ b/libriscan/libriscan/settings.py
@@ -202,3 +202,6 @@ MEDIA_URL = "images/"
 
 LOGOUT_REDIRECT_URL = "/"
 
+# File upload settings
+ALLOWED_UPLOAD_TYPES = ["image/tiff", "image/jpeg", "image/png"]
+MAX_UPLOAD_SIZE = 5 * 1024 * 1024  # 5 MB


### PR DESCRIPTION
- FileUpload Component: Implement a drag-and-drop with file format and size validation 
- Validated to accept only TIFF, PNG, and JPEG/JPG image files with a maximum size of 5MB. 
- Upon successful upload, the image is stored on the server at the `/mnt/images/` path.
- Enable the Extract button after successful upload
- Adds Loading state

https://github.com/user-attachments/assets/9798effc-2447-444f-b8d9-046b10ac3dc8

https://github.com/user-attachments/assets/0fcc2a3e-2d2c-4e5b-8c5f-4b3a17afc9bf

