### PR TITLE
Move gunicorn config to conf file, with sample

### DIFF
--- a/libriscan/entrypoint.sh
+++ b/libriscan/entrypoint.sh
@@ -6,4 +6,4 @@ python manage.py migrate --noinput
 
 python manage.py collectstatic --noinput
 
-python -m gunicorn --bind 0.0.0.0:8000 --workers 5 --timeout 120 libriscan.wsgi:application
+python -m gunicorn -c ./mnt/gunicorn.conf.py libriscan.wsgi:application

--- a/sample-config/gunicorn.conf.py
+++ b/sample-config/gunicorn.conf.py
@@ -1,0 +1,26 @@
+import multiprocessing
+
+# Gunicorn Settings
+# See https://docs.gunicorn.org/en/stable/settings.html for full details and additional options
+
+# socket address to bind
+bind = "0.0.0.0:8000"
+
+# calculate number of workers
+workers = multiprocessing.cpu_count() * 2 + 1
+
+# use threaded workers
+worker_class = 'gthread'
+
+# if this value is not 1, gthread workers will be used regardless of the worker_class
+threads = multiprocessing.cpu_count() * 2 if worker_class == 'gthread' else 1
+
+# worker timeout in seconds
+timeout = 120
+
+# restart a worker after a given number of requests. 
+# some jitter keeps them all from restarting at the same time
+max_requests = 500
+max_requests_jitter = 25
+
+


### PR DESCRIPTION
Gunicorn is the server that actually runs Django. This moves its runtime parameters out of the entrypoint script to a user-manageable config file.  The gunicorn.conf.py file also gives us the ability to dynamically determine an appropriate number of workers and threads based on the actual hardware running the server.

The timeout of 120s is overkill. Once we have a better handle on async/tasks for the extractor service, we can remove it.