### PR TITLE
[Feature] UI: Implement Upload page, Extract, Stylize Export Options for Page

### DIFF
--- a/libriscan/biblios/templates/biblios/collection_detail.html
+++ b/libriscan/biblios/templates/biblios/collection_detail.html
@@ -36,9 +36,9 @@
         <ul class="list bg-base-100 rounded-box shadow divide-base-200">
           {% for series in collection.series_set.all %}
             <li class="px-4 py-3 flex items-center gap-2 hover:bg-accent/10 transition rounded-box">
-              <span class="inline-flex items-center justify-center size-8 rounded-full bg-accent/20">
-                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-5">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25" />
+              <span class="inline-flex items-center justify-center size-8 rounded-full bg-secondary/10">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-5 text-secondary">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12.75V12A2.25 2.25 0 0 1 4.5 9.75h15A2.25 2.25 0 0 1 21.75 12v.75m-8.69-6.44-2.12-2.12a1.5 1.5 0 0 0-1.061-.44H4.5A2.25 2.25 0 0 0 2.25 6v12a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18V9a2.25 2.25 0 0 0-2.25-2.25h-5.379a1.5 1.5 0 0 1-1.06-.44Z" />
                 </svg>
               </span>
               <a href="{{ series.get_absolute_url }}" class="font-medium hover:underline">{{ series }}</a>

--- a/libriscan/biblios/templates/biblios/components/forms/text_display.html
+++ b/libriscan/biblios/templates/biblios/components/forms/text_display.html
@@ -13,9 +13,16 @@
       </label>
       <div class="tab-content bg-base-100 border-base-300 p-6">
         <div class="prose">
-          <div id="wordContainer" class="flex flex-wrap gap-4 p-4">
-            <!-- Words will be dynamically inserted here -->
+          <div class="flex flex-wrap gap-4 p-4">
+            {% if words %}
+              {% for word in words %}
+                <span>{{ word }}</span>
+              {% endfor %}
+            {% else %}
+              <p class="text-base-content/60">No text extracted yet.</p>
+            {% endif %}
           </div>
+          <div id="wordContainer" class="flex flex-wrap gap-4 p-4"></div>
           {% include 'biblios/components/forms/word_details.html' %}
         </div>
       </div>

--- a/libriscan/biblios/templates/biblios/components/forms/word_details.html
+++ b/libriscan/biblios/templates/biblios/components/forms/word_details.html
@@ -58,8 +58,8 @@ function updateWordDetails(wordInfo) {
       div.innerHTML = `
         <span class="font-medium">${suggestion.word}</span>
         <div class="flex items-center gap-3">
-          <span class="text-sm">${suggestion.confidence}%</span>
-          <progress class="${getProgressClass(suggestion.confidence)} w-24" value="${suggestion.confidence}" max="100"></progress>
+          <span class="text-sm">Frequency count: ${suggestion.confidence}</span>
+          <input type="range" min="0" max="100" value="${suggestion.confidence}" class="range w-24" disabled />
         </div>
       `;
       suggestionsList.appendChild(div);

--- a/libriscan/biblios/templates/biblios/document_detail.html
+++ b/libriscan/biblios/templates/biblios/document_detail.html
@@ -1,29 +1,110 @@
-{% extends "biblios/index.html" %}
+{% extends "biblios/base.html" %}
 {% block content %}
-  <h3>{{ document }}</h3>
-  <ul class="list">
-    <li class="list-row">Pages</li>
-    {% for page in document.pages.all %}
-      <li class="list-row">
-        <a href="{{ page.get_absolute_url }}">Page {{ page.number }}</a>
-      </li>
-    {% empty %}
-      <li class="list-row">No pages</li>
-    {% endfor %}
-    <li>
-      <a href="{% url 'page_create' keys.owner keys.collection_slug document.identifier %}">Add New Page</a>
-    </li>
-  </ul>
-  <ul class="list">
-    <li class="list-row">Downloads</li>
-    <li class="list-row">
-      <a href="{% url 'export_pdf' keys.owner keys.collection_slug document.identifier %}">PDF</a>
-    </li>
-    <li class="list-row">
-      <a href="{% url 'export_textpdf' keys.owner keys.collection_slug document.identifier %}">Text-only PDF</a>
-    </li>
-    <li class="list-row">
-      <a href="{% url 'export_text' keys.owner keys.collection_slug document.identifier %}">Text file</a>
-    </li>
-  </ul>
+        <!-- Breadcrumb Navigation with Icons -->
+        <nav class="mb-6 text-sm breadcrumbs">
+            <ul>
+          <li>
+              <a href="{{ document.series.collection.owner.get_absolute_url }}" class="flex items-center gap-1 hover:underline text-primary">
+              <span class="inline-flex items-center justify-center size-5 rounded bg-primary/10">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-4 text-primary">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 21v-8.25M15.75 21v-8.25M8.25 21v-8.25M3 9l9-6 9 6m-1.5 12V10.332A48.36 48.36 0 0 0 12 9.75c-2.551 0-5.056.2-7.5.582V21M3 21h18M12 6.75h.008v.008H12V6.75Z" />
+                </svg>
+              </span>
+            {{ document.series.collection.owner }}
+              </a>
+          </li>
+          <li>
+              <a href="{{ document.series.collection.get_absolute_url }}" class="flex items-center gap-1 hover:underline text-primary">
+            <span class="inline-flex items-center justify-center size-5 rounded bg-accent/10">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-4 text-accent">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 10h16M4 14h16M4 18h16" />
+                </svg>
+            </span>
+            {{ document.series.collection }}
+              </a>
+          </li>
+          <li>
+              <a href="{{ document.series.get_absolute_url }}" class="flex items-center gap-1 hover:underline text-primary">
+              <span class="inline-flex items-center justify-center size-5 rounded bg-secondary/10">
+                <svg xmlns="http://www.w3.org/2000/svg" class="size-4 text-secondary" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.25 12.75V12A2.25 2.25 0 0 1 4.5 9.75h15A2.25 2.25 0 0 1 21.75 12v.75m-8.69-6.44-2.12-2.12a1.5 1.5 0 0 0-1.061-.44H4.5A2.25 2.25 0 0 0 2.25 6v12a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18V9a2.25 2.25 0 0 0-2.25-2.25h-5.379a1.5 1.5 0 0 1-1.06-.44Z" /></svg>
+              </span>
+            {{ document.series }}
+              </a>
+          </li>
+          <li>
+              <span class="flex items-center gap-1 text-base-content/60">
+            <span class="inline-flex items-center justify-center size-5 rounded bg-warning/20">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-4 text-neutral">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25" />
+                </svg>
+            </span>
+            {{ document }}
+              </span>
+          </li>
+            </ul>
+        </nav></svg>
+            </ul>
+        </nav>
+
+        <!-- Document Header Card -->
+        <div class="card bg-base-100 shadow mb-6">
+            <div class="card-body">
+                <h2 class="card-title text-xl font-bold mb-4 flex items-center gap-2">
+                    <span class="inline-flex items-center justify-center size-8 rounded-full bg-warning/20">
+                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-5">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25" />
+                      </svg>
+                    </span>
+                    {{ document }}
+                </h2>
+                
+                <!-- Pages Section -->
+                <div class="mb-2 text-base font-semibold text-base-content/80">Pages in this document:</div>
+                  <ul class="bg-base-100 rounded-box shadow divide-base-200">
+                    {% for page in document.pages.all %}
+                      <li class="px-4 py-3 flex items-center justify-between hover:bg-secondary/10 transition rounded-box">
+                        <a href="{{ page.get_absolute_url }}" class="flex items-center gap-3 group">
+                          <span class="inline-flex items-center justify-center size-6 rounded bg-info/10">
+                            <span class="text-xs font-medium text-info">{{ page.number }}</span>
+                          </span>
+                          <span class="text-sm font-medium group-hover:underline">Page {{ page.number }}</span>
+                        </a>
+                      </li>
+                    {% empty %}
+                      <li class="px-4 py-3 text-center text-sm opacity-60">No pages in this document yet.</li>
+                    {% endfor %}
+                  </ul>
+                  <div class="mt-4 flex justify-end">
+                      <a href="{% url 'page_create' keys.owner keys.collection_slug document.identifier %}" class="btn btn-secondary btn-md">
+                          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m3.75 9v6m3-3H9m1.5-12H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
+                          </svg></svg>
+                          Add New Page
+                      </a>
+                  </div>
+                </div>
+
+                <!-- Downloads Export Section -->
+                <div>
+                    <div class="mb-3 text-base font-semibold text-base-content/80 flex items-center gap-2">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="size-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M9 19l3 3m0 0l3-3m-3 3V10" /></svg>
+                        Export options:
+                    </div>
+                    <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+                        <a href="{% url 'export_pdf' keys.owner keys.collection_slug document.identifier %}" class="btn btn btn-error btn-sm justify-start">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="size-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" /></svg>
+                            PDF with Images
+                        </a>
+                        <a href="{% url 'export_textpdf' keys.owner keys.collection_slug document.identifier %}" class="btn btn btn-warning btn-sm justify-start">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="size-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" /></svg>
+                            Text-only PDF
+                        </a>
+                        <a href="{% url 'export_text' keys.owner keys.collection_slug document.identifier %}" class="btn btn btn-success btn-sm justify-start">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="size-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" /></svg>
+                            Plain Text
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
 {% endblock content %}

--- a/libriscan/biblios/templates/biblios/page.html
+++ b/libriscan/biblios/templates/biblios/page.html
@@ -6,16 +6,16 @@ document.addEventListener('htmx:beforeRequest', e => {
 </script>
 {% extends "biblios/base.html" %}
 {% block content %}
-<div class="container mx-auto p-4">
-  <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+<div class="container mx-auto p-4 h-full">
+  <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 h-full">
     <!-- Left: Page Image & Actions -->
-    <div class="flex flex-col items-center">
-      <div class="card bg-base-100 shadow-sm w-full max-w-md">
-        <div class="card-body p-4">
+    <div class="flex flex-col items-center h-full w-full">
+      <div class="card bg-base-100 shadow-sm w-full h-full">
+        <div class="card-body p-4 h-full flex flex-col">
           <h2 class="card-title text-xl font-bold mb-2">Page {{ page.number }}</h2>
           <figure class="mb-4 flex justify-center">
             {% if page.image %}
-              <img src="{{ page.image.url }}" alt="Page Image" class="rounded-lg object-contain max-h-96 w-full border border-base-300" />
+              <img src="{{ page.image.url }}" alt="Page Image" class="rounded-lg object-cover h-full w-full border border-base-300" style="min-height:24rem;max-height:100%;" />
             {% else %}
               <div class="bg-base-200 rounded-lg h-96 w-full flex items-center justify-center text-base-content/60">No image available</div>
             {% endif %}
@@ -32,8 +32,8 @@ document.addEventListener('htmx:beforeRequest', e => {
         </div>
       </div>
     </div>
-    <!-- Right: Extracted Text -->
-    <div id="rightColumn" class="w-full">
+  <!-- Right: Extracted Text -->
+  <div id="rightColumn" class="h-full w-full">
       {% if page.words.exists %}
         {% include "biblios/components/forms/text_display.html" with words=page.words.all %}
       {% else %}

--- a/libriscan/biblios/templates/biblios/page.html
+++ b/libriscan/biblios/templates/biblios/page.html
@@ -1,21 +1,43 @@
 {% extends "biblios/base.html" %}
 {% block content %}
-  <h4>{{ page }} Extractor Test</h4>
-  <div>
-    <div class="card m-4 w-80">
-      <h5>Page {{ page.number }}</h5>
-      <figure>
-        {% if page.image %}<img width=auto height=auto src="{{ page.image.url }}" />{% endif %}
-      </figure>
-      <div class="card-body">
-        <button hx-post="{% url 'page_extract' keys.owner keys.collection_slug keys.doc page.number %}"
-                hx-target="#extraction"
-                {% if page.has_extraction %}disabled{% endif %}>Extract</button>
+<div class="container mx-auto p-4">
+  <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+    <!-- Left Column: Page Image & Actions -->
+    <div class="w-full flex flex-col items-center">
+      <div class="card bg-base-100 shadow-sm w-full max-w-md">
+        <div class="card-body p-4">
+          <h5 class="card-title text-xl font-bold mb-2">Page {{ page.number }}</h5>
+          <figure class="mb-4 flex justify-center">
+            {% if page.image %}
+              <img src="{{ page.image.url }}" alt="Page Image" class="rounded-lg object-contain max-h-96 w-full border border-base-300" />
+            {% else %}
+              <div class="bg-base-200 rounded-lg h-96 w-full flex items-center justify-center text-base-content/60">No image available</div>
+            {% endif %}
+          </figure>
+          <button hx-post="{% url 'page_extract' keys.owner keys.collection_slug keys.doc page.number %}"
+                  hx-target="#extraction"
+                  hx-swap="outerHTML"
+                  class="btn btn-primary w-full"
+                  {% if page.has_extraction %}disabled{% endif %}>
+            Extract
+          </button>
+        </div>
       </div>
     </div>
-    <div id="extraction" class="card m-4 w-80">
-      <h3>Extracted Text</h3>
-      <p>{{ page.words.all|join:' ' }}</p>
+
+    <!-- Right Column: Extracted Info or Text Display -->
+    <div class="w-full">
+      {% if page.words.exists %}
+        {% include "biblios/components/forms/text_display.html" with words=page.words.all %}
+      {% else %}
+        <div id="extraction" class="card bg-base-100 shadow-sm w-full">
+          <div class="card-body p-6">
+            <h3 class="card-title text-2xl mb-4">Extracted Text</h3>
+            <p class="text-base-content/60">No text extracted yet.</p>
+          </div>
+        </div>
+      {% endif %}
     </div>
   </div>
+</div>
 {% endblock %}

--- a/libriscan/biblios/templates/biblios/page.html
+++ b/libriscan/biblios/templates/biblios/page.html
@@ -22,7 +22,7 @@ document.addEventListener('htmx:beforeRequest', e => {
           </figure>
           <button
             hx-post="{% url 'page_extract' keys.owner keys.collection_slug keys.doc page.number %}"
-            hx-target="#extraction"
+            hx-target="#extractPrompt"
             hx-swap="outerHTML"
             class="btn btn-primary w-full"
             id="extractBtn"
@@ -33,16 +33,16 @@ document.addEventListener('htmx:beforeRequest', e => {
       </div>
     </div>
     <!-- Right: Extracted Text -->
-    <div>
+    <div id="rightColumn" class="w-full">
       {% if page.words.exists %}
         {% include "biblios/components/forms/text_display.html" with words=page.words.all %}
       {% else %}
-        <div id="extraction" class="card bg-base-100 shadow-sm w-full">
-          <div class="card-body p-6">
-            <h3 class="card-title text-2xl mb-4">Extracted Text</h3>
-            <p class="text-base-content/60">No text extracted yet.</p>
-          </div>
-        </div>
+       <div id="extractPrompt" class="card bg-base-100 shadow-sm h-full">
+        <div class="card-body flex flex-col justify-center items-center h-full text-center p-6">
+          <h2 class="card-title text-2xl mb-4">No Text Extracted Yet</h2>
+          <p class="mb-4">Click <span class="font-bold">Extract</span> for intelligent extraction.</p>
+        </div>  
+      </div>
       {% endif %}
     </div>
   </div>

--- a/libriscan/biblios/templates/biblios/page.html
+++ b/libriscan/biblios/templates/biblios/page.html
@@ -1,12 +1,18 @@
+<script>
+// Disable Extract button on HTMX request
+document.addEventListener('htmx:beforeRequest', e => {
+  if (e.target?.id === 'extractBtn') e.target.disabled = true;
+});
+</script>
 {% extends "biblios/base.html" %}
 {% block content %}
 <div class="container mx-auto p-4">
   <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
-    <!-- Left Column: Page Image & Actions -->
-    <div class="w-full flex flex-col items-center">
+    <!-- Left: Page Image & Actions -->
+    <div class="flex flex-col items-center">
       <div class="card bg-base-100 shadow-sm w-full max-w-md">
         <div class="card-body p-4">
-          <h5 class="card-title text-xl font-bold mb-2">Page {{ page.number }}</h5>
+          <h2 class="card-title text-xl font-bold mb-2">Page {{ page.number }}</h2>
           <figure class="mb-4 flex justify-center">
             {% if page.image %}
               <img src="{{ page.image.url }}" alt="Page Image" class="rounded-lg object-contain max-h-96 w-full border border-base-300" />
@@ -14,19 +20,20 @@
               <div class="bg-base-200 rounded-lg h-96 w-full flex items-center justify-center text-base-content/60">No image available</div>
             {% endif %}
           </figure>
-          <button hx-post="{% url 'page_extract' keys.owner keys.collection_slug keys.doc page.number %}"
-                  hx-target="#extraction"
-                  hx-swap="outerHTML"
-                  class="btn btn-primary w-full"
-                  {% if page.has_extraction %}disabled{% endif %}>
+          <button
+            hx-post="{% url 'page_extract' keys.owner keys.collection_slug keys.doc page.number %}"
+            hx-target="#extraction"
+            hx-swap="outerHTML"
+            class="btn btn-primary w-full"
+            id="extractBtn"
+            {% if page.has_extraction %}disabled{% endif %}>
             Extract
           </button>
         </div>
       </div>
     </div>
-
-    <!-- Right Column: Extracted Info or Text Display -->
-    <div class="w-full">
+    <!-- Right: Extracted Text -->
+    <div>
       {% if page.words.exists %}
         {% include "biblios/components/forms/text_display.html" with words=page.words.all %}
       {% else %}

--- a/libriscan/biblios/templates/biblios/page_form.html
+++ b/libriscan/biblios/templates/biblios/page_form.html
@@ -1,7 +1,7 @@
 {% extends "biblios/index.html" %}
 
 {% block content %}
-<form enctype="multipart/form-data" method="post" class="card bg-base-100 shadow max-w-md mx-auto mt-8 p-6 space-y-4">
+<form enctype="multipart/form-data" method="post" class="card bg-base-100 shadow max-w-md mx-auto mt-8 p-6 space-y-4" id="pageUploadForm">
     {% csrf_token %}
     <div class="space-y-6">
         {% for field in form.visible_fields %}
@@ -23,6 +23,18 @@
         </div>
         {% endfor %}
     </div>
-    <button type="submit" class="btn btn-primary w-full">Upload</button>
+    <button type="submit" class="btn btn-primary w-full" id="uploadBtn" disabled>Upload</button>
 </form>
+</script>
+<script>
+    document.addEventListener('DOMContentLoaded', () => {
+        const fileInput = document.querySelector('#pageUploadForm input[type="file"]');
+        const uploadBtn = document.getElementById('uploadBtn');
+        if (fileInput && uploadBtn) {
+            const toggle = () => uploadBtn.disabled = !fileInput.files.length;
+            fileInput.addEventListener('change', toggle);
+            toggle();
+        }
+    });
+</script>
 {% endblock content %}

--- a/libriscan/biblios/templates/biblios/page_form.html
+++ b/libriscan/biblios/templates/biblios/page_form.html
@@ -10,7 +10,7 @@
             {% if field.field.widget.input_type == "number" %}
                 <input type="number" name="{{ field.html_name }}" id="{{ field.id_for_label }}" class="input input-bordered input-lg rounded-lg w-full focus:ring-2 focus:ring-primary/60 transition-all duration-150 placeholder:text-base-content/60" value="{{ field.value|default_if_none:'' }}" placeholder="Enter page number" {% if field.field.required %}required{% endif %}>
             {% elif field.field.widget.input_type == "file" %}
-                <input type="file" name="{{ field.html_name }}" id="{{ field.id_for_label }}" class="file-input file-input-bordered w-full focus:ring-2 focus:ring-primary/60 transition-all duration-150" {% if field.field.required %}required{% endif %}>
+                <input type="file" name="{{ field.html_name }}" id="{{ field.id_for_label }}" accept=".jpeg,.jpg,.png,.tiff,image/jpeg,image/png,image/tiff" class="file-input file-input-bordered w-full focus:ring-2 focus:ring-primary/60 transition-all duration-150" {% if field.field.required %}required{% endif %}>
             {% else %}
                 {{ field }}
             {% endif %}

--- a/libriscan/biblios/templates/biblios/page_form.html
+++ b/libriscan/biblios/templates/biblios/page_form.html
@@ -1,11 +1,28 @@
 {% extends "biblios/index.html" %}
 
 {% block content %}
-
-<form enctype="multipart/form-data" method="post">
+<form enctype="multipart/form-data" method="post" class="card bg-base-100 shadow max-w-md mx-auto mt-8 p-6 space-y-4">
     {% csrf_token %}
-    {{ form }}
-    <input type="submit" value="Submit">
+    <div class="space-y-6">
+        {% for field in form.visible_fields %}
+        <div class="form-control">
+            <label for="{{ field.id_for_label }}" class="label font-semibold text-lg text-base-content mb-2">{{ field.label }}</label>
+            {% if field.field.widget.input_type == "number" %}
+                <input type="number" name="{{ field.html_name }}" id="{{ field.id_for_label }}" class="input input-bordered input-lg rounded-lg w-full focus:ring-2 focus:ring-primary/60 transition-all duration-150 placeholder:text-base-content/60" value="{{ field.value|default_if_none:'' }}" placeholder="Enter page number" {% if field.field.required %}required{% endif %}>
+            {% elif field.field.widget.input_type == "file" %}
+                <input type="file" name="{{ field.html_name }}" id="{{ field.id_for_label }}" class="file-input file-input-bordered w-full focus:ring-2 focus:ring-primary/60 transition-all duration-150" {% if field.field.required %}required{% endif %}>
+            {% else %}
+                {{ field }}
+            {% endif %}
+            {% if field.help_text %}
+                <p class="text-xs text-gray-500 mt-1">{{ field.help_text }}</p>
+            {% endif %}
+            {% for error in field.errors %}
+                <p class="text-error text-sm mt-1">{{ error }}</p>
+            {% endfor %}
+        </div>
+        {% endfor %}
+    </div>
+    <button type="submit" class="btn btn-primary w-full">Upload</button>
 </form>
-
 {% endblock content %}

--- a/libriscan/biblios/templates/biblios/series_detail.html
+++ b/libriscan/biblios/templates/biblios/series_detail.html
@@ -24,7 +24,7 @@
                 <li>
                     <a href="{{ series.get_absolute_url }}" class="flex items-center gap-1 hover:underline text-primary">
                         <span class="inline-flex items-center justify-center size-5 rounded bg-secondary/10">
-                            <svg xmlns="http://www.w3.org/2000/svg" class="size-4 text-secondary" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25" /></svg>
+                            <svg xmlns="http://www.w3.org/2000/svg" class="size-4 text-secondary" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.25 12.75V12A2.25 2.25 0 0 1 4.5 9.75h15A2.25 2.25 0 0 1 21.75 12v.75m-8.69-6.44-2.12-2.12a1.5 1.5 0 0 0-1.061-.44H4.5A2.25 2.25 0 0 0 2.25 6v12a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18V9a2.25 2.25 0 0 0-2.25-2.25h-5.379a1.5 1.5 0 0 1-1.06-.44Z" /></svg>
                         </span>
                         {{ series }}
                     </a>
@@ -36,7 +36,9 @@
             <div class="card-body">
                 <h2 class="card-title text-xl font-bold mb-2 flex items-center gap-2">
                     <span class="inline-flex items-center justify-center size-8 rounded-full bg-secondary/10">
-                        <svg xmlns="http://www.w3.org/2000/svg" class="size-5 text-secondary" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25" /></svg>
+                        <svg xmlns="http://www.w3.org/2000/svg" class="size-5 text-secondary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.25 12.75V12A2.25 2.25 0 0 1 4.5 9.75h15A2.25 2.25 0 0 1 21.75 12v.75m-8.69-6.44-2.12-2.12a1.5 1.5 0 0 0-1.061-.44H4.5A2.25 2.25 0 0 0 2.25 6v12a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18V9a2.25 2.25 0 0 0-2.25-2.25h-5.379a1.5 1.5 0 0 1-1.06-.44Z" />
+                        </svg>
                     </span>
                     {{ series }}
                 </h2>

--- a/libriscan/biblios/templates/biblios/series_detail.html
+++ b/libriscan/biblios/templates/biblios/series_detail.html
@@ -42,13 +42,15 @@
                     </span>
                     {{ series }}
                 </h2>
+
+                <!-- Documents Section -->
                 <div class="mb-2 text-base font-semibold text-base-content/80">Documents in this series:</div>
                 <ul class="list bg-base-100 rounded-box shadow divide-base-200">
                     {% for doc in series.documents.all %}
                         <li class="px-4 py-3 flex items-center gap-2 hover:bg-secondary/10 transition rounded-box">
                             <span class="inline-flex items-center justify-center size-8 rounded-full bg-warning/20">
                                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-5">
-                                    <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25" />
                                 </svg>
                             </span>
                             <a href="{{ doc.get_absolute_url }}" class="font-medium hover:underline">{{ doc }}</a>

--- a/libriscan/biblios/templates/biblios/words.html
+++ b/libriscan/biblios/templates/biblios/words.html
@@ -1,4 +1,0 @@
-<p>{% for word in words %}
-{{word.text}}
-{% endfor %}
-</p>

--- a/libriscan/biblios/views.py
+++ b/libriscan/biblios/views.py
@@ -239,7 +239,7 @@ def extract_text(request, short_name, collection_slug, identifier, number):
 
     context = {"words": extractor.get_words()}
 
-    return render(request, "biblios/words.html", context)
+    return render(request, "biblios/components/forms/text_display.html", context)
 
 
 def export_pdf(request, short_name, collection_slug, identifier, use_image=True):


### PR DESCRIPTION
- Stylized Page details and Page forms to allow upload, extract, and export
- Added file format check using generic input format.
- Added interactions to disable and enable based on the expected outcome, like the upload button
- Cleaned up SVG for consistency, size, and color

### TODO:
- Migrate to FilePond for OOB file upload features
- Add spinner loading feedback on the right column when extraction is running
- Stylize raw extract text with color-coded dash or dotted format if button styling is not moving forward
- Figure out the suggestion tuple from the TextBlocks when clicked
- Potentially, consider pagination for Pages and load accordingly

https://github.com/user-attachments/assets/45e8fcdd-d20f-446b-bb2f-8423408598cc

