### PR TITLE
Feature/74 authentication middleware

### DIFF
--- a/libriscan/biblios/tests/test_biblios.py
+++ b/libriscan/biblios/tests/test_biblios.py
@@ -1,4 +1,4 @@
-from django.test import TestCase
+from django.test import TestCase, Client
 from django.contrib.auth import get_user_model
 from django.db.utils import IntegrityError
 
@@ -55,6 +55,16 @@ class BibliosTests(TestCase):
             passes = False
 
         self.assertTrue(passes)
+
+    def test_login_is_reachable(self):
+        # Checking that the login required middleware doesn't cause redirect loops when logging in
+        from libriscan.settings import LOGIN_URL
+        response = self.client.get(LOGIN_URL, follow=True)
+        # The redirect should only be one hop
+        self.assertEqual(len(response.redirect_chain), 1)
+        # The page can be successfully reached
+        self.assertEqual(response.status_code, 200)
+
 
 
 # This is not the right place for this.

--- a/libriscan/biblios/views.py
+++ b/libriscan/biblios/views.py
@@ -1,16 +1,15 @@
 import logging
 import os
 from django.conf import settings
-from django.http import HttpResponseRedirect, HttpResponse
+from django.http import HttpResponse
 from django.shortcuts import render
 from django.core.files.storage import default_storage
 from django.core.files.base import ContentFile
 from django.views.generic import ListView, DetailView
 from django.views.generic.edit import CreateView, DeleteView, UpdateView
 from django.views.decorators.http import require_http_methods
-from django.contrib.auth.decorators import login_required
+from django.contrib.auth.decorators import login_not_required
 from django.urls import reverse_lazy
-from django.db import models
 
 from rules.contrib.views import AutoPermissionRequiredMixin, permission_required
 
@@ -26,7 +25,6 @@ def index(request):
     return render(request, "biblios/index.html", context)
 
 
-@login_required
 def scan(request):
     context = {
         "allowed_upload_types": settings.ALLOWED_UPLOAD_TYPES,
@@ -166,7 +164,6 @@ class PageCreateView(AutoPermissionRequiredMixin, CreateView):
         return self.form_valid(form) if form.is_valid() else self.form_invalid(form)
 
 
-@login_required
 @require_http_methods(["POST"])
 def handle_upload(request):
     """Handle file uploads from FilePond."""

--- a/libriscan/libriscan/settings.py
+++ b/libriscan/libriscan/settings.py
@@ -61,6 +61,7 @@ MIDDLEWARE = [
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.auth.middleware.LoginRequiredMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",


### PR DESCRIPTION
Turns on login required by default for all views. With this change, instead of opting in tons of views with the @login-required decorator, we only need to opt out the ones that should not be protected with @login-not-required. 

The main concern here is ensuring the login URL itself doesn't cause infinite redirects, but it doesn't _seem_ to be an issue in my local testing. We'll need to do some extra work later with other auth pages like PW resets, and any intentionally public pages we might design.

- Add LoginRequiredMiddleware middleware
- Remove @login_required from views
- Test that the requirement does not cause redirect loops on the actual login URL

Closes #74