### PR TITLE
Create/update collections; update orgs

### DIFF
--- a/libriscan/biblios/forms.py
+++ b/libriscan/biblios/forms.py
@@ -2,7 +2,7 @@ from django import forms
 from django.conf import settings
 from django.contrib.auth.forms import UserCreationForm, UserChangeForm
 
-from biblios.models import User, Document, Page
+from biblios.models import User, Collection, Document, Page
 
 
 # Custom user forms from https://testdriven.io/blog/django-custom-user-model/
@@ -16,6 +16,12 @@ class CustomUserChangeForm(UserChangeForm):
     class Meta:
         model = User
         fields = ("email",)
+
+
+class CollectionForm(forms.ModelForm):
+    class Meta:
+        model = Collection
+        fields = ("owner", "name", "slug")
 
 
 class DocumentForm(forms.ModelForm):
@@ -34,17 +40,21 @@ class FilePondUploadForm(forms.Form):
     image = forms.ImageField()
 
     def clean_image(self):
-        image = self.cleaned_data.get('image')
+        image = self.cleaned_data.get("image")
         if not image:
-            raise forms.ValidationError('No file was submitted.')
+            raise forms.ValidationError("No file was submitted.")
 
         # Check file type
-        if image.content_type not in getattr(settings, 'ALLOWED_UPLOAD_TYPES', []):
-            raise forms.ValidationError('Invalid file type. Please upload TIFF, JPEG, or PNG files only.')
+        if image.content_type not in getattr(settings, "ALLOWED_UPLOAD_TYPES", []):
+            raise forms.ValidationError(
+                "Invalid file type. Please upload TIFF, JPEG, or PNG files only."
+            )
 
         # Check file size
-        max_size = getattr(settings, 'MAX_UPLOAD_SIZE', 5 * 1024 * 1024)
+        max_size = getattr(settings, "MAX_UPLOAD_SIZE", 5 * 1024 * 1024)
         if image.size > max_size:
-            raise forms.ValidationError('File size exceeds limit. Please upload a smaller file.')
+            raise forms.ValidationError(
+                "File size exceeds limit. Please upload a smaller file."
+            )
 
         return image

--- a/libriscan/biblios/templates/collection_create.html
+++ b/libriscan/biblios/templates/collection_create.html
@@ -1,0 +1,11 @@
+{% extends "biblios/base.html" %}
+
+{% block content %}
+
+<form method="post">
+    {% csrf_token %}
+    {{ form }}
+    <input type="submit" value="Submit">
+</form>
+
+{% endblock content %}

--- a/libriscan/biblios/templates/collection_update.html
+++ b/libriscan/biblios/templates/collection_update.html
@@ -1,0 +1,11 @@
+{% extends "biblios/base.html" %}
+
+{% block content %}
+
+<form method="post">
+    {% csrf_token %}
+    {{ form }}
+    <input type="submit" value="Submit">
+</form>
+
+{% endblock content %}

--- a/libriscan/biblios/templates/orgaanization_update.html
+++ b/libriscan/biblios/templates/orgaanization_update.html
@@ -1,0 +1,11 @@
+{% extends "biblios/base.html" %}
+
+{% block content %}
+
+<form method="post">
+    {% csrf_token %}
+    {{ form }}
+    <input type="submit" value="Submit">
+</form>
+
+{% endblock content %}

--- a/libriscan/biblios/urls.py
+++ b/libriscan/biblios/urls.py
@@ -6,76 +6,96 @@ urlpatterns = [
     # Core pages
     path("", views.index, name="index"),
     path("scan/", views.scan, name="scan"),
-    
     # File handling
     path("upload/", views.handle_upload, name="handle_upload"),
-    
-    # Organization structure
     path("consortiums/<int:pk>/", views.ConsortiumDetail.as_view(), name="consortium"),
     path("organizations", views.organization_list, name="organization-list"),
+    # Organization details
     path(
         "<slug:short_name>/",
-        views.OrganizationDetail.as_view(),
-        name="organization",
-    ),
-    # Collection URLs
-    path(
-        "<slug:short_name>/<slug:collection_slug>/",
         include(
             [
+                path("", views.OrganizationDetail.as_view(), name="organization"),
                 path(
-                    "",
-                    views.collection_detail,
-                    name="collection",
+                    "update/",
+                    views.OrganizationUpdate.as_view(),
+                    name="organization_update",
                 ),
                 path(
-                    "new-document/",
-                    views.DocumentCreateView.as_view(),
-                    name="document_create",
+                    "new-collection/",
+                    views.CollectionCreate.as_view(),
+                    name="collection_create",
                 ),
+                # Collection URLs
                 path(
-                    "<slug:series_slug>-series/",
-                    views.SeriesDetail.as_view(),
-                    name="series",
-                ),
-                # Document URLs
-                path(
-                    "<slug:identifier>/",
+                    "<slug:collection_slug>/",
                     include(
                         [
                             path(
                                 "",
-                                views.DocumentDetail.as_view(),
-                                name="document",
+                                views.collection_detail,
+                                name="collection",
                             ),
                             path(
-                                "pdf/",
-                                views.export_pdf,
-                                {"use_image": True},
-                                name="export_pdf",
+                                "update/",
+                                views.CollectionUpdate.as_view(),
+                                name="collection_update",
                             ),
                             path(
-                                "pdftext/",
-                                views.export_pdf,
-                                {"use_image": False},
-                                name="export_textpdf",
-                            ),
-                            path("text/", views.export_text, name="export_text"),
-                            # page URLs
-                            path(
-                                "page/new",
-                                views.PageCreateView.as_view(),
-                                name="page_create",
+                                "new-document/",
+                                views.DocumentCreateView.as_view(),
+                                name="document_create",
                             ),
                             path(
-                                "page/<int:number>/",
-                                views.PageDetail.as_view(),
-                                name="page",
+                                "<slug:series_slug>-series/",
+                                views.SeriesDetail.as_view(),
+                                name="series",
                             ),
+                            # Document URLs
                             path(
-                                "page<int:number>/extract/",
-                                views.extract_text,
-                                name="page_extract",
+                                "<slug:identifier>/",
+                                include(
+                                    [
+                                        path(
+                                            "",
+                                            views.DocumentDetail.as_view(),
+                                            name="document",
+                                        ),
+                                        path(
+                                            "pdf/",
+                                            views.export_pdf,
+                                            {"use_image": True},
+                                            name="export_pdf",
+                                        ),
+                                        path(
+                                            "pdftext/",
+                                            views.export_pdf,
+                                            {"use_image": False},
+                                            name="export_textpdf",
+                                        ),
+                                        path(
+                                            "text/",
+                                            views.export_text,
+                                            name="export_text",
+                                        ),
+                                        # page URLs
+                                        path(
+                                            "page/new",
+                                            views.PageCreateView.as_view(),
+                                            name="page_create",
+                                        ),
+                                        path(
+                                            "page/<int:number>/",
+                                            views.PageDetail.as_view(),
+                                            name="page",
+                                        ),
+                                        path(
+                                            "page<int:number>/extract/",
+                                            views.extract_text,
+                                            name="page_extract",
+                                        ),
+                                    ]
+                                ),
                             ),
                         ]
                     ),


### PR DESCRIPTION
This change adds views and form definition for more user-facing CRUD operations.

- For Collection, add:
  - Form definition
  - Create view and URL ("org/new-collection")
  - Update view and URL ("org/collection/update")
  - Functional stub template
- For Organization, add:
  - Update view and URL ("org/update")
  - Functional stub template

The templates are just bare minimum HTML so I could confirm the views are working. And I built these with separate view and update pages for speed, but if we want more of an inline editing experience we can definitely change this