### PR TITLE
Feature/email config

### DIFF
--- a/libriscan/libriscan/.env.sample
+++ b/libriscan/libriscan/.env.sample
@@ -1,4 +1,5 @@
 LB_ALLOWED_HOSTS = your_host_here
+LB_TRUSTED_ORIGINS = https://your_host_here
 LB_SECRET_KEY = your_real_key_here
 
 LB_EMAIL_HOST = your_smtp_host

--- a/libriscan/libriscan/settings.py
+++ b/libriscan/libriscan/settings.py
@@ -36,9 +36,9 @@ SECRET_KEY = os.environ.get("LB_SECRET_KEY")
 DEBUG = os.environ.get("LB_DEBUG", False)
 
 ALLOWED_HOSTS = os.environ.get("LB_ALLOWED_HOSTS", "127.0.0.1").split(",")
-CSRF_TRUSTED_ORIGINS = os.environ.get(
-    "DJANGO_TRUSTED_ORIGINS", "http://localhost"
-).split(",")
+CSRF_TRUSTED_ORIGINS = os.environ.get("LB_TRUSTED_ORIGINS", "http://localhost").split(
+    ","
+)
 SESSION_COOKIE_SECURE = True
 SECURE_SSL_REDIRECT = not DEBUG
 


### PR DESCRIPTION
This change adds the ability to configure Django's email settings via .env file.

- Check the .env file for any email configuration settings. Any that aren't found are treated as None, which is how send_mail() would use them anyway.
  - Email might not send if the fields aren't set correctly, but nothing will crash
- Add examples to the sample .env file
- Change all env vars to use the LB prefix instead of DJANGO
  - This wasn't a planned change, but I decided LB would be more self-explanatory for a library

Note the change to the previous env variables! You'll need to update your .env file after merging.