### PR TITLE
[Feature] Enable Pan Zoomable image using OpenSeaDragon

### DIFF
--- a/libriscan/biblios/static/css/openseadragon-viewer.css
+++ b/libriscan/biblios/static/css/openseadragon-viewer.css
@@ -1,0 +1,55 @@
+#openseadragon-viewer {
+  position: relative;
+  background-color: hsl(var(--b2));
+  transition: all 0.3s ease;
+  cursor: grab;
+}
+
+#openseadragon-viewer:active {
+  cursor: grabbing;
+}
+
+#openseadragon-viewer:hover {
+  box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+}
+
+.openseadragon-container .navigator {
+  border: 1px solid hsl(var(--bc) / 0.2);
+  background-color: hsl(var(--b1) / 0.9);
+  border-radius: 0.5rem;
+}
+
+/* Zoom controls */
+.openseadragon-container .zoom-in,
+.openseadragon-container .zoom-out,
+.openseadragon-container .home,
+.openseadragon-container .full-page {
+  background-color: hsl(var(--b1));
+  border: 1px solid hsl(var(--bc) / 0.2);
+  border-radius: 0.375rem;
+  transition: all 0.2s ease;
+}
+
+.openseadragon-container .zoom-in:hover,
+.openseadragon-container .zoom-out:hover,
+.openseadragon-container .home:hover,
+.openseadragon-container .full-page:hover {
+  background-color: hsl(var(--b2));
+  border-color: hsl(var(--bc) / 0.3);
+}
+
+.openseadragon-container .openseadragon-message {
+  background-color: hsl(var(--b1) / 0.95);
+  color: hsl(var(--bc));
+  border-radius: 0.5rem;
+  padding: 1rem;
+}
+
+/* Draggable cursor for canvas */
+.openseadragon-container canvas {
+  cursor: grab !important;
+}
+
+.openseadragon-container canvas:active {
+  cursor: grabbing !important;
+}

--- a/libriscan/biblios/static/js/openseadragon-viewer.js
+++ b/libriscan/biblios/static/js/openseadragon-viewer.js
@@ -1,0 +1,92 @@
+/**
+ * OpenSeadragon Viewer
+ * Handles image zoom and pan with auto-height adjustment
+ */
+
+let viewerInstance = null;
+
+/**
+ * Initialize OpenSeadragon viewer
+ */
+function initializeViewer(imageUrl, containerId = 'openseadragon-viewer') {
+  if (viewerInstance) {
+    viewerInstance.destroy();
+    viewerInstance = null;
+  }
+
+  const container = document.getElementById(containerId);
+  if (!container || !imageUrl) return null;
+
+  try {
+    viewerInstance = OpenSeadragon({
+      id: containerId,
+      prefixUrl: 'https://cdnjs.cloudflare.com/ajax/libs/openseadragon/4.1.0/images/',
+      tileSources: { type: 'image', url: imageUrl },
+      
+      // Display settings
+      minZoomLevel: 1,
+      defaultZoomLevel: 1,
+      homeFillsViewer: true,
+      constrainDuringPan: true,
+      visibilityRatio: 1,
+      
+      // Zoom behavior
+      zoomPerScroll: 1.2,
+      maxZoomPixelRatio: 3,
+      
+      // Controls
+      showNavigationControl: true,
+      navigationControlAnchor: OpenSeadragon.ControlAnchor.TOP_LEFT,
+      
+      // Mouse gestures
+      gestureSettingsMouse: {
+        scrollToZoom: true,
+        clickToZoom: false,
+        dblClickToZoom: true
+      },
+      
+      // Touch gestures
+      gestureSettingsTouch: {
+        pinchToZoom: true,
+        dblClickToZoom: true
+      }
+    });
+
+    // Auto-adjust height to match image aspect ratio
+    viewerInstance.addHandler('open', function() {
+      const image = viewerInstance.world.getItemAt(0);
+      if (!image) return;
+      
+      const aspectRatio = image.getContentSize().y / image.getContentSize().x;
+      const height = Math.max(400, Math.min(1200, container.clientWidth * aspectRatio));
+      container.style.height = height + 'px';
+    });
+
+    return viewerInstance;
+  } catch (error) {
+    console.error('Viewer initialization failed:', error);
+    return null;
+  }
+}
+
+/**
+ * Reinitialize for HTMX page swaps
+ */
+function reinitializeViewer(imageUrl, containerId = 'openseadragon-viewer') {
+  return initializeViewer(imageUrl, containerId);
+}
+
+/**
+ * Clean up viewer instance
+ */
+function destroyViewer() {
+  if (viewerInstance) {
+    viewerInstance.destroy();
+    viewerInstance = null;
+  }
+}
+
+// Export to global scope
+window.initializeViewer = initializeViewer;
+window.reinitializeViewer = reinitializeViewer;
+window.destroyViewer = destroyViewer;

--- a/libriscan/biblios/templates/biblios/base.html
+++ b/libriscan/biblios/templates/biblios/base.html
@@ -1,4 +1,5 @@
 {% load django_htmx %}
+{% load static %}
 <!doctype html>
 <html lang="en-US" data-theme="light" id="html-root">
 
@@ -16,6 +17,10 @@
   <link href="https://unpkg.com/filepond-plugin-image-preview/dist/filepond-plugin-image-preview.css" rel="stylesheet">
   <script src="https://unpkg.com/filepond-plugin-image-preview/dist/filepond-plugin-image-preview.js"></script>
   <script src="https://unpkg.com/filepond/dist/filepond.js"></script>
+  
+  <!-- OpenSeadragon Dependencies -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/openseadragon/4.1.0/openseadragon.min.js"></script>
+  <link rel="stylesheet" href="{% static 'css/openseadragon-viewer.css' %}">
   
   <!-- Theme Toggle Script -->
   <script>

--- a/libriscan/biblios/templates/biblios/page.html
+++ b/libriscan/biblios/templates/biblios/page.html
@@ -1,10 +1,6 @@
-<script>
-// Disable Extract button on HTMX request
-document.addEventListener('htmx:beforeRequest', e => {
-  if (e.target?.id === 'extractBtn') e.target.disabled = true;
-});
-</script>
 {% extends "biblios/base.html" %}
+{% load static %}
+
 {% block content %}
 <nav class="mb-6 text-sm breadcrumbs">
   <ul>
@@ -102,20 +98,16 @@ document.addEventListener('htmx:beforeRequest', e => {
           </div>
           <figure class="mb-4 flex justify-center">
             {% if page.image %}
-              <img src="{{ page.image.url }}" alt="Page Image" class="rounded-lg object-cover h-full w-full border border-base-300" style="min-height:24rem;max-height:100%;" />
+              <!-- OpenSeadragon Viewer Container -->
+              <div id="openseadragon-viewer" 
+                   class="rounded-lg border border-base-300 w-full"
+                   style="min-height:32rem; width:100%;"
+                   data-image-url="{{ page.image.url }}">
+              </div>
             {% else %}
               <div class="bg-base-200 rounded-lg h-96 w-full flex items-center justify-center text-base-content/60">No image available</div>
             {% endif %}
           </figure>
-          <button
-            hx-post="{% url 'page_extract' keys.owner keys.collection_slug keys.doc page.number %}"
-            hx-target="#extractPrompt"
-            hx-swap="outerHTML"
-            class="btn btn-primary w-full"
-            id="extractBtn"
-            {% if page.has_extraction %}disabled{% endif %}>
-            Extract
-          </button>
         </div>
       </div>
     </div>
@@ -127,6 +119,15 @@ document.addEventListener('htmx:beforeRequest', e => {
        <div id="extractPrompt" class="card bg-base-100 shadow-sm h-full">
         <div class="card-body flex flex-col justify-center items-center h-full text-center p-6">
           <h2 class="card-title text-2xl mb-4">No Text Extracted Yet</h2>
+          <button
+            hx-post="{% url 'page_extract' keys.owner keys.collection_slug keys.doc page.number %}"
+            hx-target="#extractPrompt"
+            hx-swap="outerHTML"
+            class="btn btn-primary w-full"
+            id="extractBtn"
+            {% if page.has_extraction %}disabled{% endif %}>
+            Extract
+          </button>
           <p class="mb-4">Click <span class="font-bold">Extract</span> for intelligent extraction.</p>
         </div>  
       </div>
@@ -134,4 +135,45 @@ document.addEventListener('htmx:beforeRequest', e => {
     </div>
   </div>
 </div>
+
+<script>
+  // Disable Extract button on HTMX request
+  document.addEventListener('htmx:beforeRequest', e => {
+    if (e.target?.id === 'extractBtn') e.target.disabled = true;
+  });
+</script>
+
+<!-- OpenSeadragon Initialization Script -->
+<script src="{% static 'js/openseadragon-viewer.js' %}"></script>
+<script>
+  // Initialize viewer on page load
+  document.addEventListener('DOMContentLoaded', function() {
+    const viewer = document.getElementById('openseadragon-viewer');
+    if (viewer) {
+      const imageUrl = viewer.dataset.imageUrl;
+      if (imageUrl) {
+        initializeViewer(imageUrl);
+      }
+    }
+  });
+
+  // Reinitialize viewer after HTMX navigation (page swaps)
+  document.body.addEventListener('htmx:afterSettle', function(event) {
+    const viewer = document.getElementById('openseadragon-viewer');
+    if (viewer) {
+      const imageUrl = viewer.dataset.imageUrl;
+      if (imageUrl) {
+        console.log('HTMX navigation detected, reinitializing viewer...');
+        reinitializeViewer(imageUrl);
+      }
+    }
+  });
+
+  // Clean up viewer before HTMX swap to prevent memory leaks
+  document.body.addEventListener('htmx:beforeSwap', function(event) {
+    if (window.viewerInstance) {
+      destroyViewer();
+    }
+  });
+</script>
 {% endblock %}


### PR DESCRIPTION
- Library: OpenSeadragon v4.1.0

- Zoom Range: 1x (full-width) to 3x (pixel-level)

- Scroll Increment: 1.2x per scroll

#### Mouse Controls

- [x] __Scroll to Zoom__ - Use mouse wheel to zoom in/out
- [x] __Click & Drag to Pan__ - Click and drag to move around the image
- [x] __Double-Click to Zoom In__ - Double-click anywhere on the image to zoom in
- [x] __Draggable Cursor__ - Cursor changes to grab hand (🖐️) on hover, grabbing hand (✊) while dragging

#### Navigation Controls (Top-Left Corner)

- [x] __Zoom In Button__ (+) - Click to zoom in incrementally
- [x] __Zoom Out Button__ (−) - Click to zoom out incrementally
- [x] __Home Button__ - Click to reset view to full-width fit

#### Touch Controls (Mobile/Tablet)

- [x] __Pinch to Zoom__ - Use two fingers to pinch in/out for zoom
- [x] __Touch & Drag to Pan__ - Single finger drag to move around
- [x] __Double-Tap to Zoom In__ - Double-tap to zoom into the image

https://github.com/user-attachments/assets/f9dc6674-6c5c-4832-835c-104a247d3df1
