### PR TITLE
Clamp decimal fields

### DIFF
--- a/libriscan/biblios/models.py
+++ b/libriscan/biblios/models.py
@@ -383,7 +383,7 @@ class TextBlock(BibliosModel):
     }
 
     # Confidence level thresholds
-    CONF_ACCEPTED = 99.99
+    CONF_ACCEPTED = 99.999
     CONF_HIGH = 90.0
     CONF_MEDIUM = 80.0
     CONF_LOW = 50.0
@@ -404,7 +404,7 @@ class TextBlock(BibliosModel):
     confidence = models.DecimalField(
         max_digits=5,
         decimal_places=3,
-        validators=[MinValueValidator(0), MaxValueValidator(100)],
+        validators=[MinValueValidator(0), MaxValueValidator(CONF_ACCEPTED)],
     )
 
     # Controls whether this word should be included from document exports.
@@ -461,6 +461,7 @@ class TextBlock(BibliosModel):
 
     def save(self, **kwargs):
         """Generate spellcheck suggestions on save"""
+
         self.suggestions = self.__get_suggestions__()
         # In case the word text has been specified as an update_field, include the suggestions too
         if (


### PR DESCRIPTION
Fixes #170 .

Root cause was that in certain cases, the Textract response can contain values for DecimalFields that caused the InvalidOperation error. Specifically, when `confidence` is 100% or any of the coordinate fields are 1. (It's not clear to me if this is because they exceed the values used for MaxValueValidator on those fields or if it's because they're integers.)

The ideal way to fix this would be to extend TextBlock.save(), but we can't: the extraction process uses bulk_create which does not call the model's save method. Instead I added a new step in the extraction process that performs these checks when initializing an unsaved TextBlock for a word in the extractor response.