### PR TITLE
Feature/spellcheck performance

### DIFF
--- a/libriscan/biblios/services/extractors.py
+++ b/libriscan/biblios/services/extractors.py
@@ -73,7 +73,7 @@ class BaseExtractor(object):
         }
 
     # Don't override this; it has safety checks to keep invalid textblocks from being loaded
-    def __create_block__(self, word):
+    def __clean_block__(self, word):
         """Safely extract a text block."""
 
         textblock = self.__create_text_block__(word)
@@ -115,13 +115,13 @@ class BaseExtractor(object):
                     text, self.page.document.use_long_s_detection
                 )
 
-            new_text.append(self.__create_block__(w))
+            new_text.append(self.__clean_block__(w))
 
         logger.info(f"Found {len(self.distinct_words)} distinct words")
 
         TextBlock.objects.bulk_create(new_text)
 
-        return words
+        return new_text
 
 
 class AWSExtractor(BaseExtractor):


### PR DESCRIPTION
This change makes the text extractor a bit more performant by only generating spellcheck suggestions for the unique words in the extraction response. So if "the" appears five times, we only spellcheck it once and reuse those results for the other four instances of it.

Using the standard test.jpg as a reference, there are 387 text blocks on the page but only 229 distinct words. The full extraction process currently takes 15s on my local machine, and 12s with this change.

Regression testing will be important here. This seems to work fine for me, but it's definitely a significant change in the extraction process.

- Track unique words and their spellcheck suggestions in the extraction process
- Rename the `create_block` method to `__clean_block__` to make the purpose more clear
- Fix the extractor logging