### PR TITLE
Add docs to index view

### DIFF
--- a/libriscan/biblios/views.py
+++ b/libriscan/biblios/views.py
@@ -39,8 +39,18 @@ class OrgPermissionRequiredMixin(AutoPermissionRequiredMixin):
 
 
 def index(request):
-    orgs = Organization.objects.all()
-    context = {"app_name": "Libriscan", "orgs": orgs}
+    context = {"app_name": "Libriscan"}
+    if request.user.is_authenticated:
+        # The most recent doc the user edited
+        context["latest_doc"] = Document.history.filter(
+            history_user=request.user
+        ).latest()
+        # All docs in all orgs the user is a member of
+        context["documents"] = Document.objects.filter(
+            series__collection__owner__in=request.user.userrole_set.values_list(
+                "organization", flat=True
+            )
+        )
     return render(request, "biblios/index.html", context)
 
 


### PR DESCRIPTION
Adds a user's document info to the homepage view. This covers the backend requirements for #199 but not the frontend.

- Add `latest_doc` to the page context, which returns the user's most recent HistoricalDocument record
  - This has all the same attributes as a normal Document object but not the same methods. The actual Document is available under `latest_doc.historical_object`, so you can e.g. get_absolute_url() from that.
  - The `.get_x_display()` methods are available directly though
  - Also check out the audit info: `history_date`, `history_type`, etc.
- Add `documents` to the context. This is a list of all Document objects that belong to an org the user has access to.
  -  These are the full objects, not a simple value list as we discussed. I think we'll get more by retaining the methods like `get_absolute_url` than we would save by losing them.