### PR TITLE
Track current extraction tasks

### DIFF
--- a/libriscan/biblios/tasks.py
+++ b/libriscan/biblios/tasks.py
@@ -1,4 +1,7 @@
-from huey.contrib.djhuey import db_task
+from huey.contrib.djhuey import db_task, periodic_task
+from huey.contrib.djhuey import HUEY as huey
+from huey import crontab
+
 
 # Define any tasks for Huey to queue in this file.
 # They can be simple wrappers to other functions/methods elsewhere -- complex belongs in services.
@@ -7,4 +10,20 @@ from huey.contrib.djhuey import db_task
 
 @db_task()
 def queue_extraction(extractor):
-    return extractor.get_words()
+    # Confirm that the requested page can still extract text
+    if extractor.page.can_extract:
+        return extractor.get_words()
+    else:
+        return None
+
+
+@periodic_task(crontab(minute="*/10"))
+def check_timeouts():
+    """Periodically clean out any timed-out extraction handles from the Huey store."""
+    from datetime import datetime, timedelta
+
+    for task, start_time in huey.all_results().items():
+        if task.startswith("extracting-") and datetime.today() - start_time > timedelta(
+            minutes=10
+        ):
+            huey.get(task)


### PR DESCRIPTION
Adds a few layers of to prevent multiple extraction jobs from running on the same page. Basically, we're using Huey's built-in key store to track pages when a user requests extraction on them, and use it to prevent new extraction tasks from running.

- Add a key to the Huey store when extraction is called from the Page, with the current timestamp as a value
- Check that the page is still `can_extract` before queuing extraction for it
- When extraction is requested via the `extract_text` view, see if the Page has a current extraction key in the store before queuing a new extraction task
  - If the extraction key was found and it's older than ten minutes, remove it from the store
- Include the Page's extraction key in the PageDetail context as `extracting`, so the front end can tell if extraction is running on a new page load. The value is the start time but this can be treated as a boolean.
- If the Page has text blocks, remove its extraction key from the store on PageDetail load.
- Add a recurring process that checks for extraction keys that began more than ten minutes ago, and purge them. This runs every ten minutes automatically.

Other changes:
- Fix logging for models.py and views.py
- Use TextBlock.CONF_ACCEPTED instead of the raw value when updating a text block

Next steps:
- Consider changing the hard-coded ten minute extraction timeout to a configurable setting
- Add front end controls that use `extracting` in some way -- blocking the extraction button, starting the extraction animation, etc.

Side note: Odds are good I missed some dumb bug in here, but it's midnight as I'm finishing it and I just can't find it...