### PR TITLE
[Bugfix] Fix missing series (AttributeError) when uploaded page is visited. 

### DIFF
--- a/libriscan/biblios/models/documents.py
+++ b/libriscan/biblios/models/documents.py
@@ -193,8 +193,8 @@ class Page(BibliosModel):
 
     def get_absolute_url(self):
         keys = {
-            "short_name": self.document.series.collection.owner.short_name,
-            "collection_slug": self.document.series.collection.slug,
+            "short_name": self.document.collection.owner.short_name,
+            "collection_slug": self.document.collection.slug,
             "identifier": self.document.identifier,
             "number": self.number,
         }
@@ -206,7 +206,7 @@ class Page(BibliosModel):
         return (
             not self.has_extraction
             and CloudService.objects.filter(
-                organization=self.document.series.collection.owner
+                organization=self.document.collection.owner
             ).exists()
             and huey.get(self.extraction_key, peek=True) is None
         )
@@ -221,7 +221,7 @@ class Page(BibliosModel):
 
     # Hand off this work to the Huey background task
     def generate_extraction(self):
-        extractor = self.document.series.collection.owner.cloudservice.extractor
+        extractor = self.document.collection.owner.cloudservice.extractor
         q = queue_extraction(extractor(self))
         logger.info(f"Queuing {q.id}")
 

--- a/libriscan/biblios/services/extractors.py
+++ b/libriscan/biblios/services/extractors.py
@@ -132,7 +132,7 @@ class AWSExtractor(BaseExtractor):
     def __get_extraction__(self):
         import boto3
 
-        service = self.page.document.series.collection.owner.cloudservice
+        service = self.page.document.collection.owner.cloudservice
         client = boto3.client(
             "textract",
             region_name="us-east-1",

--- a/libriscan/biblios/templates/biblios/document_detail.html
+++ b/libriscan/biblios/templates/biblios/document_detail.html
@@ -4,25 +4,26 @@
         <nav class="mb-3 text-sm breadcrumbs">
             <ul>
           <li>
-              <a href="{{ document.series.collection.owner.get_absolute_url }}" class="flex items-center gap-1 hover:underline text-primary">
+              <a href="{{ document.collection.owner.get_absolute_url }}" class="flex items-center gap-1 hover:underline text-primary">
               <span class="inline-flex items-center justify-center size-5 rounded bg-primary/10">
                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-4 text-primary">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M12 21v-8.25M15.75 21v-8.25M8.25 21v-8.25M3 9l9-6 9 6m-1.5 12V10.332A48.36 48.36 0 0 0 12 9.75c-2.551 0-5.056.2-7.5.582V21M3 21h18M12 6.75h.008v.008H12V6.75Z" />
                 </svg>
               </span>
-            {{ document.series.collection.owner }}
+            {{ document.collection.owner }}
               </a>
           </li>
           <li>
-              <a href="{{ document.series.collection.get_absolute_url }}" class="flex items-center gap-1 hover:underline text-primary">
+              <a href="{{ document.collection.get_absolute_url }}" class="flex items-center gap-1 hover:underline text-primary">
             <span class="inline-flex items-center justify-center size-5 rounded bg-accent/10">
                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-4 text-accent">
               <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 10h16M4 14h16M4 18h16" />
                 </svg>
             </span>
-            {{ document.series.collection }}
+            {{ document.collection }}
               </a>
           </li>
+          {% if document.series %}
           <li>
               <a href="{{ document.series.get_absolute_url }}" class="flex items-center gap-1 hover:underline text-primary">
               <span class="inline-flex items-center justify-center size-5 rounded bg-secondary/10">
@@ -31,6 +32,7 @@
             {{ document.series }}
               </a>
           </li>
+          {% endif %}
           <li>
               <span class="flex items-center gap-1 text-base-content/60">
             <span class="inline-flex items-center justify-center size-5 rounded bg-warning/20">

--- a/libriscan/biblios/templates/biblios/page.html
+++ b/libriscan/biblios/templates/biblios/page.html
@@ -5,23 +5,24 @@
 <nav class="mb-3 text-sm breadcrumbs">
   <ul>
     <li>
-      <a href="{{ page.document.series.collection.owner.get_absolute_url }}" class="flex items-center gap-1 hover:underline text-primary">
+      <a href="{{ page.document.collection.owner.get_absolute_url }}" class="flex items-center gap-1 hover:underline text-primary">
         <span class="inline-flex items-center justify-center size-5 rounded bg-primary/10">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-4 text-primary">
             <path stroke-linecap="round" stroke-linejoin="round" d="M12 21v-8.25M15.75 21v-8.25M8.25 21v-8.25M3 9l9-6 9 6m-1.5 12V10.332A48.36 48.36 0 0 0 12 9.75c-2.551 0-5.056.2-7.5.582V21M3 21h18M12 6.75h.008v.008H12V6.75Z" />
           </svg>
         </span>
-        {{ page.document.series.collection.owner }}
+        {{ page.document.collection.owner }}
       </a>
     </li>
     <li>
-      <a href="{{ page.document.series.collection.get_absolute_url }}" class="flex items-center gap-1 hover:underline text-primary">
+      <a href="{{ page.document.collection.get_absolute_url }}" class="flex items-center gap-1 hover:underline text-primary">
         <span class="inline-flex items-center justify-center size-5 rounded bg-accent/10">
           <svg xmlns="http://www.w3.org/2000/svg" class="size-4 text-accent" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 10h16M4 14h16M4 18h16" /></svg>
         </span>
-        {{ page.document.series.collection }}
+        {{ page.document.collection }}
       </a>
     </li>
+    {% if page.document.series %}
     <li>
       <a href="{{ page.document.series.get_absolute_url }}" class="flex items-center gap-1 hover:underline text-primary">
         <span class="inline-flex items-center justify-center size-5 rounded bg-secondary/10">
@@ -30,6 +31,7 @@
         {{ page.document.series }}
       </a>
     </li>
+    {% endif %}
     <li>
       <a href="{{ page.document.get_absolute_url }}" class="flex items-center gap-1 hover:underline text-primary">
         <span class="inline-flex items-center justify-center size-5 rounded bg-warning/20">

--- a/libriscan/biblios/tests/test_biblios.py
+++ b/libriscan/biblios/tests/test_biblios.py
@@ -87,8 +87,8 @@ class BibliosTests(TestCase):
 
         response = merge_blocks(
             request,
-            page.document.series.collection.owner.short_name,
-            page.document.series.collection.slug,
+            page.document.collection.owner.short_name,
+            page.document.collection.slug,
             page.document.identifier,
             page.number,
         )
@@ -108,8 +108,8 @@ class BibliosTests(TestCase):
 
         response = merge_blocks(
             request,
-            page.document.series.collection.owner.short_name,
-            page.document.series.collection.slug,
+            page.document.collection.owner.short_name,
+            page.document.collection.slug,
             page.document.identifier,
             page.number,
         )

--- a/libriscan/biblios/views/documents.py
+++ b/libriscan/biblios/views/documents.py
@@ -309,7 +309,7 @@ def extract_text(request, short_name, collection_slug, identifier, number):
         "collection_slug": collection_slug,
         "identifier": identifier,
         "number": number,
-        "owner": page.document.series.collection.owner,
+        "owner": page.document.collection.owner,
     }
 
     # Return the loading template immediately


### PR DESCRIPTION
### Page broke when visiting the uploaded page without the series attribute.

- Fixed an AttributeError that occurred when accessing a page for a document without a series. The code accessed document.series.collection, but series can be None

```
  File "/Users/seintun/code/harvard/Libriscan/libriscan/biblios/models/documents.py", line 196, in get_absolute_url
    "short_name": self.document.series.collection.owner.short_name,
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'collection'
ERROR "GET /APL/test-collection/123/ HTTP/1.1" 500 175403
```