### PR TITLE
Squashing console bugs on eventListener with null

### DIFF
--- a/libriscan/biblios/static/js/confidence-toggle.js
+++ b/libriscan/biblios/static/js/confidence-toggle.js
@@ -64,8 +64,8 @@ class ConfidenceToggle {
   attachEventListeners() {
     // Individual toggle handlers
     Object.entries(this.toggles).forEach(([level, checkbox]) => {
-      checkbox?.addEventListener('change', (e) => {
-        e.stopPropagation(); // Keep dropdown open
+      checkbox?.addEventListener('change', (event) => {
+        event.stopPropagation(); // Keep dropdown open
         this.toggleIndicator(level, checkbox.checked);
         this.syncToggleAll();
         this.savePreferences();
@@ -73,8 +73,8 @@ class ConfidenceToggle {
     });
     
     // "All" toggle handler
-    this.toggleAll?.addEventListener('change', (e) => {
-      e.stopPropagation(); // Keep dropdown open
+    this.toggleAll?.addEventListener('change', (event) => {
+      event.stopPropagation(); // Keep dropdown open
       const isChecked = this.toggleAll.checked;
       Object.entries(this.toggles).forEach(([level, checkbox]) => {
         if (checkbox) {
@@ -87,9 +87,9 @@ class ConfidenceToggle {
 
     // Keep dropdown open on label click
     const dropdownContent = document.querySelector('.dropdown-content');
-    dropdownContent?.addEventListener('click', (e) => {
-      if (e.target.closest('label')) {
-        e.stopPropagation();
+    dropdownContent?.addEventListener('click', (event) => {
+      if (event.target.closest('label')) {
+        event.stopPropagation();
       }
     });
   }

--- a/libriscan/biblios/static/js/tutorial.js
+++ b/libriscan/biblios/static/js/tutorial.js
@@ -11,18 +11,18 @@ class LibriscanTutorial {
   }
 
   init() {
-    document.getElementById('startTutorial')?.addEventListener('click', (e) => {
-      e.preventDefault();
+    document.getElementById('startTutorial')?.addEventListener('click', (event) => {
+      event.preventDefault();
       this.startPageWalkthrough();
     });
 
-    document.getElementById('startKeyboardShortcuts')?.addEventListener('click', (e) => {
-      e.preventDefault();
+    document.getElementById('startKeyboardShortcuts')?.addEventListener('click', (event) => {
+      event.preventDefault();
       this.startKeyboardShortcuts();
     });
 
-    document.getElementById('startWordEditingTutorial')?.addEventListener('click', (e) => {
-      e.preventDefault();
+    document.getElementById('startWordEditingTutorial')?.addEventListener('click', (event) => {
+      event.preventDefault();
       this.startWordEditing();
     });
   }

--- a/libriscan/biblios/static/js/word_details/editor.js
+++ b/libriscan/biblios/static/js/word_details/editor.js
@@ -21,21 +21,30 @@ class WordEditor {
   }
 
   initializeEventListeners() {
-    this.editButton.onclick = () => this.enterEditMode();
-    this.saveButton.onclick = () => this.save();
-    this.revertButton.onclick = () => this.revert();
-    this.wordInput.onkeypress = (e) => { 
-      if (e.key === 'Enter') this.save(); 
-    };
-    this.wordInput.onkeydown = (e) => {
-      if (e.key === 'Escape') this.revert();
-    };
+    if (this.editButton) {
+      this.editButton.onclick = () => this.enterEditMode();
+    }
+    if (this.saveButton) {
+      this.saveButton.onclick = () => this.save();
+    }
+    if (this.revertButton) {
+      this.revertButton.onclick = () => this.revert();
+    }
+    if (this.wordInput) {
+      this.wordInput.onkeypress = (event) => { 
+        if (event.key === 'Enter') this.save(); 
+      };
+      this.wordInput.onkeydown = (event) => {
+        if (event.key === 'Escape') this.revert();
+      };
+    }
     
     // Double-click to edit
-    this.wordElement.addEventListener('dblclick', () => this.enterEditMode());
-    
-    // Visual feedback
-    this.wordElement.style.cursor = 'pointer';
+    if (this.wordElement) {
+      this.wordElement.addEventListener('dblclick', () => this.enterEditMode());
+      // Visual feedback
+      this.wordElement.style.cursor = 'pointer';
+    }
   }
 
   enterEditMode() {
@@ -61,9 +70,13 @@ class WordEditor {
 
   revert() {
     if (this.preEditWord !== null) {
-      this.wordInput.value = this.preEditWord;
-      this.wordElement.textContent = this.preEditWord;
-      this.wordElement.title = this.preEditWord;
+      if (this.wordInput) {
+        this.wordInput.value = this.preEditWord;
+      }
+      if (this.wordElement) {
+        this.wordElement.textContent = this.preEditWord;
+        this.wordElement.title = this.preEditWord;
+      }
       
       if (this.onRevert) {
         this.onRevert(this.preEditWord);
@@ -73,9 +86,11 @@ class WordEditor {
   }
 
   updateWord(word) {
-    this.wordElement.textContent = word;
-    // Add title attribute to show full word on hover when truncated
-    this.wordElement.title = word;
+    if (this.wordElement) {
+      this.wordElement.textContent = word;
+      // Add title attribute to show full word on hover when truncated
+      this.wordElement.title = word;
+    }
   }
 
   isEditingMode() {
@@ -94,15 +109,19 @@ class WordEditor {
     
     if (enabled) {
       // Save current word before editing
-      this.preEditWord = this.wordElement.textContent;
+      if (this.wordElement) {
+        this.preEditWord = this.wordElement.textContent;
+      }
       
       // Switch to edit mode
       this._toggleElements(displayModeElements, true);  // Hide
       this._toggleElements(editModeElements, false);     // Show
       
       // Set input value and focus
-      this.wordInput.value = this.wordElement.textContent;
-      this.wordInput.focus();
+      if (this.wordInput && this.wordElement) {
+        this.wordInput.value = this.wordElement.textContent;
+        this.wordInput.focus();
+      }
     } else {
       // Switch to display mode
       this._toggleElements(displayModeElements, false);  // Show

--- a/libriscan/biblios/static/js/word_details/keyboard.js
+++ b/libriscan/biblios/static/js/word_details/keyboard.js
@@ -2,7 +2,7 @@
 class WordKeyboard {
   constructor(wordDetails) {
     this.wordDetails = wordDetails;
-    this.handler = (e) => this._handleKeydown(e);
+    this.handler = (event) => this._handleKeydown(event);
   }
 
   initialize() {
@@ -13,25 +13,25 @@ class WordKeyboard {
     document.removeEventListener('keydown', this.handler);
   }
 
-  _handleKeydown(e) {
+  _handleKeydown(event) {
     if (WordEditor.isTyping() || this.wordDetails.editor.isEditingMode()) return;
 
-    const { key } = e;
+    const { key } = event;
     
     if (key === 'ArrowLeft') {
-      e.preventDefault();
+      event.preventDefault();
       this.wordDetails.goToPrevWord();
     } else if (key === 'ArrowRight') {
-      e.preventDefault();
+      event.preventDefault();
       this.wordDetails.goToNextWord();
     } else if (key >= '1' && key <= '9') {
-      e.preventDefault();
+      event.preventDefault();
       this._applySuggestion(parseInt(key) - 1);
     } else if (key === 'e' || key === 'E') {
-      e.preventDefault();
+      event.preventDefault();
       this.wordDetails.editor.enterEditMode();
     } else if (key === 'a' || key === 'A') {
-      e.preventDefault();
+      event.preventDefault();
       this.wordDetails.metadata.accept();
     }
   }

--- a/libriscan/biblios/static/js/word_details/main.js
+++ b/libriscan/biblios/static/js/word_details/main.js
@@ -82,8 +82,12 @@ class WordDetails {
     document.addEventListener('wordSelected', (event) => this.updateWordDetails(event.detail));
     document.addEventListener('printControlUpdated', (event) => this._handlePrintControlUpdate(event.detail));
     
-    this.prevWordBtn.onclick = () => this.navigation.goToPrevWord();
-    this.nextWordBtn.onclick = () => this.navigation.goToNextWord();
+    if (this.prevWordBtn) {
+      this.prevWordBtn.onclick = () => this.navigation.goToPrevWord();
+    }
+    if (this.nextWordBtn) {
+      this.nextWordBtn.onclick = () => this.navigation.goToNextWord();
+    }
     
     if (this.revertToOriginalAction) {
       this.revertToOriginalAction.onclick = () => this.revert.revertToOriginalWord();

--- a/libriscan/biblios/static/js/word_details/metadata.js
+++ b/libriscan/biblios/static/js/word_details/metadata.js
@@ -17,8 +17,8 @@ class WordMetadata {
 
   initializeEventListeners() {
     this.printControlOptions.forEach(option => {
-      option.addEventListener('click', (e) => {
-        e.preventDefault();
+      option.addEventListener('click', (event) => {
+        event.preventDefault();
         this.updatePrintControl(option.getAttribute('data-value'));
         this._closeDropdown(this.printControlDropdownBtn);
       });

--- a/libriscan/biblios/static/js/word_details/navigation.js
+++ b/libriscan/biblios/static/js/word_details/navigation.js
@@ -27,9 +27,15 @@ class WordNavigation {
       button = button.previousElementSibling;
     }
 
-    this.wordDetails.prevWordBtn.disabled = !WordBlockManager.getAdjacentWordBlock(this.wordDetails.currentWordId, 'prev');
-    this.wordDetails.nextWordBtn.disabled = !WordBlockManager.getAdjacentWordBlock(this.wordDetails.currentWordId, 'next');
-    this.wordDetails.wordPosition.textContent = `${currentPosition} of ${this.wordDetails.totalWords}`;
+    if (this.wordDetails.prevWordBtn) {
+      this.wordDetails.prevWordBtn.disabled = !WordBlockManager.getAdjacentWordBlock(this.wordDetails.currentWordId, 'prev');
+    }
+    if (this.wordDetails.nextWordBtn) {
+      this.wordDetails.nextWordBtn.disabled = !WordBlockManager.getAdjacentWordBlock(this.wordDetails.currentWordId, 'next');
+    }
+    if (this.wordDetails.wordPosition) {
+      this.wordDetails.wordPosition.textContent = `${currentPosition} of ${this.wordDetails.totalWords}`;
+    }
   }
 
   selectFirstWord() {


### PR DESCRIPTION
Squashing console error on eventListener with `null`

```
(anonymous) @ htmx.min.js:1Understand this error
2navigation.js:30 Uncaught TypeError: Cannot set properties of null (setting 'disabled')
    at WordNavigation.updateNavigationState (navigation.js:30:43)
    at WordDetails.updateWordDetails (main.js:124:21)
    at HTMLDocument.<anonymous> (main.js:82:63)
    at WordSelector.dispatchWordSelectedEvent (word_selector.js:89:14)
    at WordSelector.handleWordClick (word_selector.js:22:12)
    at HTMLButtonElement.<anonymous> (word_selector.js:9:59)
```

```
main.js:85 Uncaught TypeError: Cannot set properties of null (setting 'onclick')
    at WordDetails.initializeEventListeners (main.js:85:30)
    at new WordDetails (main.js:11:10)
    at HTMLDocument.<anonymous> (main.js:257:3)
```