### PR TITLE
Add search and filter layout to home page

### DIFF
--- a/libriscan/biblios/templates/biblios/components/layout/welcome_section.html
+++ b/libriscan/biblios/templates/biblios/components/layout/welcome_section.html
@@ -1,13 +1,80 @@
 {% load static %}
 
-<div class="hero bg-base-100 py-12">
-  <div class="hero-content text-center">
-    <div class="max-w-md">
-      <h2 class="text-3xl font-bold">Welcome to LibriScan!</h2>
-      <p class="py-6">
+<!-- Welcome Section with Search -->
+<div class="bg-base-100 py-8">
+  <div class="container mx-auto px-4 max-w-7xl">
+    <!-- Welcome Header (Left Aligned) -->
+    <div class="mb-6">
+      <h2 class="text-4xl font-bold mb-3">Welcome to LibriScan!</h2>
+      <p class="text-lg text-base-content/70">
         Start digitizing your library collection with our advanced scanning tools.
       </p>
-      <a href="{% url 'organization-list' %}" class="btn btn-primary text-white">🔎 Start Scanning</a>
     </div>
+
+    <!-- Quick Action (Left Aligned) -->
+    <div class="mb-6">
+      <a href="{% url 'organization-list' %}" class="btn btn-primary btn-lg text-white gap-2 shadow-lg hover:shadow-xl transition-all">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6A2.25 2.25 0 0 1 6 3.75h2.25A2.25 2.25 0 0 1 10.5 6v2.25a2.25 2.25 0 0 1-2.25 2.25H6a2.25 2.25 0 0 1-2.25-2.25V6ZM3.75 15.75A2.25 2.25 0 0 1 6 13.5h2.25a2.25 2.25 0 0 1 2.25 2.25V18a2.25 2.25 0 0 1-2.25 2.25H6A2.25 2.25 0 0 1 3.75 18v-2.25ZM13.5 6a2.25 2.25 0 0 1 2.25-2.25H18A2.25 2.25 0 0 1 20.25 6v2.25A2.25 2.25 0 0 1 18 10.5h-2.25a2.25 2.25 0 0 1-2.25-2.25V6ZM13.5 15.75a2.25 2.25 0 0 1 2.25-2.25H18a2.25 2.25 0 0 1 2.25 2.25V18A2.25 2.25 0 0 1 18 20.25h-2.25A2.25 2.25 0 0 1 13.5 18v-2.25Z" />
+        </svg>
+        Start Transcribing
+      </a>
+    </div>
+
+    <!-- Search and Filter Row -->
+    <div class="mb-6">
+      <div class="flex items-center">
+        
+        <!-- Search Input (Left, Medium width) -->
+        <div class="w-[400px]">
+          <input 
+            type="text" 
+            id="homepage-search"
+            placeholder="Filter documents below..." 
+            class="input input-bordered w-full"
+            autocomplete="off"
+            aria-label="Filter documents"
+          />
+          <!-- Search Results Dropdown -->
+          <div id="homepage-search-results" class="mt-2 hidden bg-base-100 shadow-xl rounded-box max-h-96 overflow-y-auto border border-base-300" role="listbox" aria-label="Search results">
+            <!-- Results will be populated here by search.js -->
+          </div>
+        </div>
+
+        <!-- Spacer to push buttons to the right -->
+        <div class="flex-1"></div>
+
+        <!-- View Toggle Buttons (Right side) -->
+        <div class="btn-group mr-4">
+          <button class="btn btn-active btn-sm gap-2">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 6.75h12M8.25 12h12m-12 5.25h12M3.75 6.75h.007v.008H3.75V6.75Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0ZM3.75 12h.007v.008H3.75V12Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm-.375 5.25h.007v.008H3.75v-.008Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z" />
+            </svg>
+            List
+          </button>
+          <button class="btn btn-sm gap-2">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6A2.25 2.25 0 0 1 6 3.75h2.25A2.25 2.25 0 0 1 10.5 6v2.25a2.25 2.25 0 0 1-2.25 2.25H6a2.25 2.25 0 0 1-2.25-2.25V6ZM3.75 15.75A2.25 2.25 0 0 1 6 13.5h2.25a2.25 2.25 0 0 1 2.25 2.25V18a2.25 2.25 0 0 1-2.25 2.25H6A2.25 2.25 0 0 1 3.75 18v-2.25ZM13.5 6a2.25 2.25 0 0 1 2.25-2.25H18A2.25 2.25 0 0 1 20.25 6v2.25A2.25 2.25 0 0 1 18 10.5h-2.25a2.25 2.25 0 0 1-2.25-2.25V6ZM13.5 15.75a2.25 2.25 0 0 1 2.25-2.25H18a2.25 2.25 0 0 1 2.25 2.25V18A2.25 2.25 0 0 1 18 20.25h-2.25A2.25 2.25 0 0 1 13.5 18v-2.25Z" />
+            </svg>
+            Grid
+          </button>
+        </div>
+
+        <!-- Filter Dropdown (Far right) -->
+        <div class="w-48">
+          <select id="filter-type" class="select select-bordered w-full">
+            <option value="all">All</option>
+            <option value="id">ID</option>
+            <option value="collection">Collection</option>
+            <option value="series">Series</option>
+            <option value="documents">Documents</option>
+          </select>
+        </div>
+
+      </div>
+    </div>
+
   </div>
 </div>
+
+<script src="{% static 'js/search.js' %}"></script>


### PR DESCRIPTION
Part of [Homepage data #199](https://github.com/Crimson-Vision/Libriscan/issues/199)

- Added search input with filter placeholder on left side
- Added List/Grid view toggle buttons on right side
- Added filter dropdown
- Changed "Start Scanning" to "Start Transcribing"
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/e93ad762-5c49-466e-8cf6-7cee60a7a5b0" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/3cb69f8a-7ab1-465e-8c06-1dffdc8584b9" />
