### PR TITLE
Provide page snippets

### DIFF
--- a/libriscan/biblios/models/documents.py
+++ b/libriscan/biblios/models/documents.py
@@ -221,6 +221,7 @@ class Page(BibliosModel):
 
     @property
     def snippet(self):
+        # Pulling the text into a list at the start means this property will only introduce one additional DB query
         words = list(self.words.filter(print_control=TextBlock.INCLUDE))
         snippet = ""
         # We might not have any words yet


### PR DESCRIPTION
This changes adds a new `snippet` property to Pages, that returns a short snippet of their printable text.

- Add a new class attribute `SNIPPET_LENGTH` to Page, to control how long the snippet is. Currently this value is 20 words.
- Add the property `snippet` that constructs and returns a string; the full text if there are few words, or "start of text ... end of text" if the page has more than SNIPPET_LENGTH words. (Or a "no extracted text" message if there are none.)

This can be used in any view or template by referencing the `snippet` field of any Page instance.