### PR TITLE
Make doc create form aware of the Series

### DIFF
--- a/libriscan/biblios/templates/biblios/series_detail.html
+++ b/libriscan/biblios/templates/biblios/series_detail.html
@@ -90,7 +90,7 @@
                     {% endfor %}
                 </ul>
                 <div class="mt-4 flex justify-end">
-                    <a href="{% url 'document_create' series.collection.owner.short_name series.collection.slug %}" class="btn btn-secondary btn-md">Add New Document</a>
+                    <a href="{% url 'document_series_create' series.collection.owner.short_name series.collection.slug series.slug %}" class="btn btn-secondary btn-md">Add New Document</a>
                 </div>
             </div>
         </div>

--- a/libriscan/biblios/urls.py
+++ b/libriscan/biblios/urls.py
@@ -58,6 +58,7 @@ urlpatterns = [
                                 views.SeriesCreateView.as_view(),
                                 name="series_create",
                             ),
+                            # Series URLs
                             path(
                                 "<slug:series_slug>-series/",
                                 include(
@@ -76,6 +77,11 @@ urlpatterns = [
                                             "delete/",
                                             views.SeriesDeleteView.as_view(),
                                             name="series_delete",
+                                        ),
+                                        path(
+                                            "new-document/",
+                                            views.DocumentCreateView.as_view(),
+                                            name="document_series_create",
                                         ),
                                     ]
                                 ),


### PR DESCRIPTION
This change makes the Create Document form aware of when it's called from a Series page. This adds a new URL within the Series, but it calls the pre-existing view and form.

- Create a new URL for the document creation form within the series URL paths
- Change the Add New Doc button on the Series page to link to that new URL instead of quietly sending the user back to the Collection
- Check for a series slug in the URL when creating the form, and default the Series dropdown to that value if it's found

Ideally in the future we would just suppress the Series field on the form in this case, like we do for Collection. But there's quite a bit more wiring that needs to take place, and would possibly require a different document creation view.

Closes #296 