### PR TITLE
Enable secure CSRF cookies

### DIFF
--- a/libriscan/libriscan/settings.py
+++ b/libriscan/libriscan/settings.py
@@ -40,6 +40,7 @@ CSRF_TRUSTED_ORIGINS = os.environ.get("LB_TRUSTED_ORIGINS", "http://localhost").
     ","
 )
 SESSION_COOKIE_SECURE = True
+CSRF_COOKIE_SECURE = True
 
 if not DEBUG:
     SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")


### PR DESCRIPTION
Small change: just configures the app to use secure CSRF cookies. Doesn't seem to negatively impact local dev servers running without SSL.

Closes #96 