### PR TITLE
Fix missing series path for revert to original

### DIFF
--- a/libriscan/biblios/views/words.py
+++ b/libriscan/biblios/views/words.py
@@ -238,8 +238,8 @@ def revert_word(request, short_name, collection_slug, identifier, number, word_i
             id=word_id,
             page__number=number,
             page__document__identifier=identifier,
-            page__document__series__collection__slug=collection_slug,
-            page__document__series__collection__owner__short_name=short_name,
+            page__document__collection__slug=collection_slug,
+            page__document__collection__owner__short_name=short_name,
         )
         try:
             # earliest() will be the creation record


### PR DESCRIPTION
@mhampson31 IDK how these bugs get reintroduced. Another bad rebase/merge?

```
ERROR Error reverting word 4843: No TextBlock matches the given query.
ERROR Internal Server Error: /APL/test-collection/TL-123/page1/word/4843/revert/
ERROR "POST /APL/test-collection/TL-123/page1/word/4843/revert/ HTTP/1.1" 500 34
```