### PR TITLE
Improve Document admin display

### DIFF
--- a/libriscan/biblios/admin.py
+++ b/libriscan/biblios/admin.py
@@ -80,13 +80,14 @@ class SeriesAdmin(admin.ModelAdmin):
 
 @admin.register(Document)
 class DocumentAdmin(SimpleHistoryAdmin):
-    list_display = ["identifier", "series", "series__collection"]
+    list_display = ["identifier", "collection", "series", "status"]
+    list_filter = ["collection", "series", "status"]
     inlines = [PagesInline, MetadataInline]
 
 
 @admin.register(Page)
 class PageAdmin(SimpleHistoryAdmin):
-    list_display = ["number", "document", "document__series__collection__owner"]
+    list_display = ["number", "document", "document__collection__owner"]
 
 
 @admin.register(UserRole)


### PR DESCRIPTION
This change is just a few small tweaks to the Document and Page admin list display.

- Change the Document display to use `document.collection` instead of `document.series.collection`
- Add the Document `status` to the display
- Change the Page display to use `document.collection` as well