### PR TITLE
Hide export section is not exportable

### DIFF
--- a/libriscan/biblios/templates/biblios/document_detail.html
+++ b/libriscan/biblios/templates/biblios/document_detail.html
@@ -198,6 +198,7 @@
                 </div>
 
                 <!-- Export Section -->
+                 {% if document.can_export %}
                 <div class="mt-6 pt-6 border-t border-base-300">
                     <div class="mb-4">
                         <h3 class="text-lg font-semibold text-base-content flex items-center gap-2 mb-1">
@@ -208,6 +209,7 @@
                         </h3>
                         <p class="text-sm text-base-content/60 ml-7">Download your document in various formats</p>
                     </div>
+                    
                     <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
                         <!-- PDF with Images Card -->
                         <a href="{% url 'export_pdf' keys.owner keys.collection_slug document.identifier %}" 
@@ -289,8 +291,9 @@
                                 </div>
                             </div>
                         </a>
-                    </div>
+                      </div>
                 </div>
+                {% endif %}
             </div>
         </div>
 


### PR DESCRIPTION
Address #279 by hiding the entire Export section of the document page when the document's `can_export` is not True. 
