### PR TITLE
[Bug] Fix template url of action button

### DIFF
--- a/libriscan/biblios/templates/biblios/components/layout/welcome_section.html
+++ b/libriscan/biblios/templates/biblios/components/layout/welcome_section.html
@@ -296,7 +296,7 @@
                 
                 <!-- Action Button -->
                 <div class="card-actions justify-end mt-4">
-                  <a href="{% url 'page-detail' textblock.instance.page.id %}" class="btn btn-sm btn-primary">
+                  <a href="{{ textblock.instance.page.get_absolute_url }}" class="btn btn-sm btn-primary">
                     Continue Editing
                   </a>
                 </div>


### PR DESCRIPTION
Fix Bug
The template was using 'page-detail', but the URL pattern is 'page'

<img width="1280" height="1009" alt="Image" src="https://github.com/user-attachments/assets/11bfd1d7-70ac-46ae-b560-3f95b1eaad31" />


```
NoReverseMatch at /
Reverse for 'page-detail' not found. 'page-detail' is not a valid view function or pattern name.
```

```
!-- Action Button -->
--
<div class="card-actions justify-end mt-4">
<a href="{% url 'page-detail' textblock.instance.page.id %}" class="btn btn-sm btn-primary">
Continue Editing

```