### PR TITLE
refactor: remove welcome section and fix tab scroll jump

### DIFF
--- a/libriscan/biblios/static/js/homepage.js
+++ b/libriscan/biblios/static/js/homepage.js
@@ -30,8 +30,8 @@ document.addEventListener('DOMContentLoaded', function() {
       const targetId = this.getAttribute('data-tab');
       document.getElementById(targetId).classList.remove('hidden');
       
-      // Save active tab in URL hash
-      window.location.hash = targetId;
+      // Save active tab in URL without scrolling
+      history.replaceState(null, null, `#${targetId}`);
     });
   });
   

--- a/libriscan/biblios/templates/biblios/components/layout/welcome_section.html
+++ b/libriscan/biblios/templates/biblios/components/layout/welcome_section.html
@@ -3,23 +3,6 @@
 <!-- Welcome Section with Search and Tabs -->
 <div class="bg-base-100 py-8">
   <div class="container mx-auto px-4">
-    <!-- Welcome Header (Left Aligned) -->
-    <div class="mb-6">
-      <h2 class="text-4xl font-bold mb-3">Welcome to LibriScan!</h2>
-      <p class="text-lg text-base-content/70">
-        Start digitizing your library collection with our advanced scanning tools.
-      </p>
-    </div>
-
-    <!-- Quick Action (Left Aligned) -->
-    <div class="mb-6">
-      <a href="{% url 'organization-list' %}" class="btn btn-primary btn-lg text-white gap-2 shadow-lg hover:shadow-xl transition-all">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6A2.25 2.25 0 0 1 6 3.75h2.25A2.25 2.25 0 0 1 10.5 6v2.25a2.25 2.25 0 0 1-2.25 2.25H6a2.25 2.25 0 0 1-2.25-2.25V6ZM3.75 15.75A2.25 2.25 0 0 1 6 13.5h2.25a2.25 2.25 0 0 1 2.25 2.25V18a2.25 2.25 0 0 1-2.25 2.25H6A2.25 2.25 0 0 1 3.75 18v-2.25ZM13.5 6a2.25 2.25 0 0 1 2.25-2.25H18A2.25 2.25 0 0 1 20.25 6v2.25A2.25 2.25 0 0 1 18 10.5h-2.25a2.25 2.25 0 0 1-2.25-2.25V6ZM13.5 15.75a2.25 2.25 0 0 1 2.25-2.25H18a2.25 2.25 0 0 1 2.25 2.25V18A2.25 2.25 0 0 1 18 20.25h-2.25A2.25 2.25 0 0 1 13.5 18v-2.25Z" />
-        </svg>
-        Start Transcribing
-      </a>
-    </div>
 
     <!-- Search and Filter Row -->
     <div class="mb-6">
@@ -58,17 +41,6 @@
             </svg>
             Grid
           </button>
-        </div>
-
-        <!-- Filter Dropdown (Far right) -->
-        <div class="w-48">
-          <select id="filter-type" class="select select-bordered w-full">
-            <option value="all">All</option>
-            <option value="id">ID</option>
-            <option value="collection">Collection</option>
-            <option value="series">Series</option>
-            <option value="documents">Documents</option>
-          </select>
         </div>
 
       </div>


### PR DESCRIPTION
Issue https://github.com/Crimson-Vision/Libriscan/issues/345

- Removed 'Welcome to LibriScan!' heading and subtitle
- Removed 'Start Transcribing' button
- Removed filter dropdown (All/ID/Collection/Series/Documents)
- Fixed tab switching scroll jump by using history.replaceState

<img width="1911" height="1055" alt="image" src="https://github.com/user-attachments/assets/b26e2f5a-bc03-4c54-b263-d1618778095c" />
