### PR TITLE
fix: prevent scroll jump when restoring tabs on page refresh

### DIFF
--- a/libriscan/biblios/static/js/homepage.js
+++ b/libriscan/biblios/static/js/homepage.js
@@ -37,11 +37,18 @@ document.addEventListener('DOMContentLoaded', function() {
   
   // Restore active tab from URL hash on page load (after pagination)
   function restoreActiveTab() {
-    const hash = window.location.hash.slice(1); // Remove # from hash
+    const hash = window.location.hash.slice(1);
     if (hash && document.getElementById(hash)) {
       const tabToActivate = document.querySelector(`[data-tab="${hash}"]`);
       if (tabToActivate) {
-        tabToActivate.click();
+        // Prevents scroll jump
+        tabs.forEach(t => {
+          t.classList.remove('tab-active', 'btn-primary', 'font-semibold', 'shadow-md', '-translate-y-0.5');
+        });
+        tabToActivate.classList.add('tab-active', 'btn-primary', 'font-semibold', 'shadow-md', '-translate-y-0.5');
+        
+        panels.forEach(panel => panel.classList.add('hidden'));
+        document.getElementById(hash).classList.remove('hidden');
       }
     }
   }


### PR DESCRIPTION
Refreshing the page causes a scroll jump when restoring the active tab. 
- Prevents scroll caused by window.location.hash
- Tab restoration on refresh.

**Changes**
- Modified `restoreActiveTab()` 
- Removed `.click()` call that caused scroll

**Testing**

1. Refresh Page on "All Documents" 
2. Change Tabs back and forth

Fixes #349