### PR TITLE
"Where You Left Off" shows more documents instead of unique entries

### DIFF
--- a/libriscan/biblios/views/base.py
+++ b/libriscan/biblios/views/base.py
@@ -116,7 +116,7 @@ def index(request):
                     # Skip records with bad data
                     continue
         except Exception:
-            pass
+            unique_textblocks = []
 
         context["recent_textblocks"] = unique_textblocks
     return render(request, "biblios/index.html", context)


### PR DESCRIPTION
- Each document now appears only once with the most recent edit
- Implemented Python-based deduplication for SQLite compatibility
- Added error handling for invalid data

Fixe for Bug #351

For testing: 
- Edit words from multiple pages from same document 
- Edit words from multiple pages from another document
- Verify on "Where You Left Off" 