### PR TITLE
Disable Extract button when cloud service is missing. Adds Extracting loading when huey is still running.

### DIFF
--- a/libriscan/biblios/templates/biblios/page.html
+++ b/libriscan/biblios/templates/biblios/page.html
@@ -205,7 +205,7 @@
             {% if page.can_extract %}
               Click <span class="font-bold">Extract</span> for intelligent extraction.
             {% else %}
-              Text extraction is not available. Please configure a cloud service for this organization.
+              Text extraction is not available. The page may already have text blocks, or a cloud service may not be configured for this organization.
             {% endif %}
           </p>
         </div>  

--- a/libriscan/biblios/views/documents.py
+++ b/libriscan/biblios/views/documents.py
@@ -471,7 +471,7 @@ def extract_text(request, short_name, collection_slug, identifier, number):
     # Validate that the page can be extracted
     if not page.can_extract:
         return HttpResponse(
-            "Text extraction is not available. Please configure a cloud service for this organization.",
+            "Text extraction is not available. The page may already have text blocks, or a cloud service may not be configured for this organization.",
             status=400
         )
 


### PR DESCRIPTION
Changes:
- Disabled Extract button when page.document.extractable is False
- Showed error message when extractable is False: "Text extraction is not available. Please configure a cloud service for this organization."
- Showed extraction loading screen when extraction is in progress (using existing extracting context variable)
- Status persists across page refreshes/navigation since the view checks extraction status on each load


https://github.com/user-attachments/assets/829dfb68-6a55-4b82-ba6a-85470e009a28

<img width="1135" height="783" alt="Screenshot 2025-11-13 at 12 26 00 PM" src="https://github.com/user-attachments/assets/de6a5c86-14d6-4cb2-a8c1-3f49cf9a8b14" />
