### PR TITLE
Add page titles to all pages

### DIFF
--- a/libriscan/biblios/templates/biblios/collection_detail.html
+++ b/libriscan/biblios/templates/biblios/collection_detail.html
@@ -1,4 +1,7 @@
 {% extends "biblios/base.html" %}
+
+{% block title %}{{ collection }} · {{ collection.owner.short_name }} · Libriscan{% endblock %}
+
 {% block content %}
   <!-- Breadcrumb Navigation with Icons -->
   <nav class="mb-3 text-sm breadcrumbs">

--- a/libriscan/biblios/templates/biblios/collection_form.html
+++ b/libriscan/biblios/templates/biblios/collection_form.html
@@ -1,5 +1,7 @@
 {% extends "biblios/base.html" %}
 
+{% block title %}Create New Collection · {{ short_name}} · Libriscan{% endblock %}
+
 {% block content %}
 <!-- Breadcrumb Navigation -->
 <nav class="mb-3 text-sm breadcrumbs">

--- a/libriscan/biblios/templates/biblios/document_detail.html
+++ b/libriscan/biblios/templates/biblios/document_detail.html
@@ -1,5 +1,8 @@
 {% extends "biblios/base.html" %}
 {% load static %}
+
+{% block title %}{{document}} · {% if document.series %}{{ document.series }} · {% endif %}{{document.collection}} · {{ document.collection.owner.short_name}} · Libriscan{% endblock %}
+
 {% block content %}
         <!-- Breadcrumb Navigation with Icons -->
         <nav class="mb-3 text-sm breadcrumbs">

--- a/libriscan/biblios/templates/biblios/document_form.html
+++ b/libriscan/biblios/templates/biblios/document_form.html
@@ -1,4 +1,7 @@
 {% extends "biblios/base.html" %}
+
+{% block title %}Create New Document · {{ collection }} · Libriscan{% endblock %}
+
 {% block content %}
     {% if object %}
         <nav class="mb-3 text-sm breadcrumbs">

--- a/libriscan/biblios/templates/biblios/organization_detail.html
+++ b/libriscan/biblios/templates/biblios/organization_detail.html
@@ -1,4 +1,7 @@
 {% extends "biblios/base.html" %}
+
+{% block title %}{{ org }} · Libriscan{% endblock %}
+
 {% block content %}
   <div class="max-w-2xl mx-auto py-10">
     <!-- Organization Card -->

--- a/libriscan/biblios/templates/biblios/organization_list.html
+++ b/libriscan/biblios/templates/biblios/organization_list.html
@@ -1,4 +1,7 @@
 {% extends "biblios/base.html" %}
+
+{% block title %}Your Organizations · Libriscan{% endblock %}
+
 {% block content %}
     <div class="container mx-auto px-4 py-8">
         <p class="mb-6 text-lg font-semibold">Organizations you can access:</p>

--- a/libriscan/biblios/templates/biblios/page.html
+++ b/libriscan/biblios/templates/biblios/page.html
@@ -1,6 +1,8 @@
 {% extends "biblios/base.html" %}
 {% load static %}
 
+{% block title %}{{page}} · {% if page.document.series %}{{ page.document.series }} · {% endif %}{{ page.document.collection }} · {{ page.document.collection.owner.short_name}} · Libriscan{% endblock %}
+
 {% block tutorial_section %}
 <!-- Tutorials Section - Only on Page View -->
 <li class="menu-title">

--- a/libriscan/biblios/templates/biblios/page_form.html
+++ b/libriscan/biblios/templates/biblios/page_form.html
@@ -1,5 +1,7 @@
 {% extends "biblios/base.html" %}
 
+{% block title %}Upload Page · Libriscan{% endblock %}
+
 {% block content %}
 <div class="min-h-screen bg-gradient-to-br from-base-200 to-base-300 py-12 px-4">
     <div class="max-w-2xl mx-auto">

--- a/libriscan/biblios/templates/biblios/series_detail.html
+++ b/libriscan/biblios/templates/biblios/series_detail.html
@@ -1,4 +1,7 @@
 {% extends "biblios/base.html" %}
+
+{% block title %}{{ series }} · {{ series.collection }} · {{ series.collection.owner.short_name }} · Libriscan{% endblock %}
+
 {% block content %}
         <!-- Breadcrumb Navigation with Icons -->
         <nav class="mb-3 text-sm breadcrumbs">

--- a/libriscan/biblios/templates/biblios/series_form.html
+++ b/libriscan/biblios/templates/biblios/series_form.html
@@ -1,5 +1,7 @@
 {% extends "biblios/base.html" %}
 
+{% block title %}Create New Series · Libriscan{% endblock %}
+
 {% block content %}
 <!-- Breadcrumb Navigation -->
 <nav class="mb-3 text-sm breadcrumbs">


### PR DESCRIPTION
Adds title blocks to most page templates -- basically following the breadcrumbs but in reverse. Create forms get "Create New X", otherwise just using each object's string representation. The file changes are all very small and should be easy to parse, but a few examples:

<img width="400" height="406" alt="image" src="https://github.com/user-attachments/assets/97aaf08a-589b-4c4d-a254-d3b6afc69389" />

<img width="637" height="406" alt="image" src="https://github.com/user-attachments/assets/74e840de-4776-48b6-90d8-c27b06068f6b" />

Closes #329 