### PR TITLE
Create Security.md

### DIFF
--- a/Security.md
+++ b/Security.md
@@ -1,0 +1,18 @@
+# Security Policy
+
+## Supported Versions
+We currently support the latest release of this project.
+
+## Reporting a Vulnerability
+If you discover a security vulnerability, please **do not create a public issue**.
+
+Instead, report it privately using GitHub's security advisory feature:
+[Submit a vulnerability report](https://github.com/Crimson-Vision/Libriscan/security/advisories/new)
+
+We will review and respond as soon as possible.
+
+## Disclosure Policy
+Do not publicly disclose the vulnerability until we confirm a fix is available.
+
+## Note
+This project may become unmaintained after December 2025. Vulnerability reports may not receive timely responses after that date.


### PR DESCRIPTION
Enabled repo's Private Security Vulnerabilities reporting, following these GitHub documentation pages:

[About repository security advisories](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability)

[Configuring private vulnerability reporting for a repository](https://docs.github.com/en/code-security/security-advisories/working-with-repository-security-advisories/configuring-private-vulnerability-reporting-for-a-repository)

Added the Security.md pointing to the form that submits private vulernabilities. This approach won't expose vulnerabilities to the public looking at the repo.

resolves #9 