### PR TITLE
Task/admin cleanup

### DIFF
--- a/libriscan/biblios/admin.py
+++ b/libriscan/biblios/admin.py
@@ -105,17 +105,6 @@ class PageAdmin(SimpleHistoryAdmin):
     list_display = ["number", "document", "document__collection__owner"]
 
 
-@admin.register(UserRole)
-class UserRoleAdmin(SimpleHistoryAdmin):
-    list_display = [
-        "user",
-        "user__first_name",
-        "user__last_name",
-        "organization",
-        "role",
-    ]
-
-
 @admin.register(User)
 class CustomUserAdmin(UserAdmin):
     add_form = CustomUserCreationForm

--- a/libriscan/biblios/admin.py
+++ b/libriscan/biblios/admin.py
@@ -48,10 +48,28 @@ class CloudServiceForm(ModelForm):
         widgets = {"client_secret": SecretKeyWidget}
 
 
-class CloudServiceInline(admin.StackedInline):
-    model = CloudService
+@admin.register(CloudService)
+class CloudServiceAdmin(SimpleHistoryAdmin):
     form = CloudServiceForm
-    extra = 1
+    list_display = ["organization", "service"]
+    fieldsets = (
+        (
+            None,
+            {
+                "fields": (
+                    "organization",
+                    "service",
+                ),
+            },
+        ),
+        (
+            None,
+            {
+                "fields": (("client_id", "client_secret"),),
+                "description": "To change the secret key, delete this cloud service record and create a new one for the organization.",
+            },
+        ),
+    )
 
 
 class MetadataInline(admin.StackedInline):
@@ -61,8 +79,8 @@ class MetadataInline(admin.StackedInline):
 
 @admin.register(Organization)
 class OrgAdmin(SimpleHistoryAdmin):
-    inlines = [UserRoleInline, CloudServiceInline]
-    list_display = ["name", "city", "state"]
+    inlines = [UserRoleInline]
+    list_display = ["name", "short_name", "primary", "city", "state"]
 
 
 @admin.register(Collection)

--- a/libriscan/biblios/admin.py
+++ b/libriscan/biblios/admin.py
@@ -63,9 +63,9 @@ class CloudServiceAdmin(SimpleHistoryAdmin):
             },
         ),
         (
-            None,
+            "Secrets",
             {
-                "fields": (("client_id", "client_secret"),),
+                "fields": ("client_id", "client_secret"),
                 "description": "To change the secret key, delete this cloud service record and create a new one for the organization.",
             },
         ),

--- a/libriscan/biblios/admin.py
+++ b/libriscan/biblios/admin.py
@@ -24,6 +24,15 @@ admin.site.site_title = "Libriscan Admin"
 admin.site.index_title = "Libriscan Admin"
 
 
+#### Custom admin forms
+class CloudServiceForm(ModelForm):
+    class Meta:
+        fields = ["service", "client_id", "client_secret"]
+        model = CloudService
+        widgets = {"client_secret": SecretKeyWidget}
+
+
+#### Inlines
 class SeriesInline(admin.TabularInline):
     model = Series
     extra = 1
@@ -41,11 +50,16 @@ class PagesInline(admin.StackedInline):
     extra = 0
 
 
-class CloudServiceForm(ModelForm):
-    class Meta:
-        fields = ["service", "client_id", "client_secret"]
-        model = CloudService
-        widgets = {"client_secret": SecretKeyWidget}
+class MetadataInline(admin.StackedInline):
+    model = DublinCoreMetadata
+    extra = 1
+
+
+#### Model admins
+@admin.register(Organization)
+class OrgAdmin(SimpleHistoryAdmin):
+    inlines = [UserRoleInline]
+    list_display = ["name", "short_name", "primary", "city", "state"]
 
 
 @admin.register(CloudService)
@@ -70,17 +84,6 @@ class CloudServiceAdmin(SimpleHistoryAdmin):
             },
         ),
     )
-
-
-class MetadataInline(admin.StackedInline):
-    model = DublinCoreMetadata
-    extra = 1
-
-
-@admin.register(Organization)
-class OrgAdmin(SimpleHistoryAdmin):
-    inlines = [UserRoleInline]
-    list_display = ["name", "short_name", "primary", "city", "state"]
 
 
 @admin.register(Collection)
@@ -113,6 +116,7 @@ class UserRoleAdmin(SimpleHistoryAdmin):
     ]
 
 
+@admin.register(User)
 class CustomUserAdmin(UserAdmin):
     add_form = CustomUserCreationForm
     form = CustomUserChangeForm
@@ -161,9 +165,7 @@ class CustomUserAdmin(UserAdmin):
     ordering = ("email",)
 
 
-admin.site.register(User, CustomUserAdmin)
-
-
+@admin.register(TextBlock)
 class TextAdmin(SimpleHistoryAdmin):
     search_fields = ("text",)
 
@@ -187,6 +189,3 @@ class TextAdmin(SimpleHistoryAdmin):
         ),
         (None, {"fields": ("suggestions",)}),
     )
-
-
-admin.site.register(TextBlock, TextAdmin)

--- a/libriscan/biblios/admin.py
+++ b/libriscan/biblios/admin.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
+from django.utils.translation import gettext_lazy as _
 from django.forms import ModelForm
-from django.forms.widgets import PasswordInput
 from simple_history.admin import SimpleHistoryAdmin
 
 from .forms import CustomUserChangeForm, CustomUserCreationForm
@@ -17,6 +17,7 @@ from .models import (
     User,
     UserRole,
 )
+from .widgets import SecretKeyWidget
 
 admin.site.site_header = "Libriscan Administration"
 admin.site.site_title = "Libriscan Admin"
@@ -44,7 +45,7 @@ class CloudServiceForm(ModelForm):
     class Meta:
         fields = ["service", "client_id", "client_secret"]
         model = CloudService
-        widgets = {"client_secret": PasswordInput}
+        widgets = {"client_secret": SecretKeyWidget}
 
 
 class CloudServiceInline(admin.StackedInline):
@@ -60,7 +61,7 @@ class MetadataInline(admin.StackedInline):
 
 @admin.register(Organization)
 class OrgAdmin(SimpleHistoryAdmin):
-    inlines = [CloudServiceInline]
+    inlines = [UserRoleInline, CloudServiceInline]
     list_display = ["name", "city", "state"]
 
 
@@ -69,13 +70,6 @@ class CollectionAdmin(SimpleHistoryAdmin):
     inlines = [SeriesInline]
     list_display = ["name", "owner"]
     prepopulated_fields = {"slug": ["name"]}
-
-
-@admin.register(Series)
-class SeriesAdmin(admin.ModelAdmin):
-    list_display = ["name", "collection"]
-    prepopulated_fields = {"slug": ["name"]}
-    list_select_related = ["collection"]
 
 
 @admin.register(Document)
@@ -125,6 +119,7 @@ class CustomUserAdmin(UserAdmin):
             {"fields": ("is_staff", "is_active", "groups", "user_permissions")},
         ),
     )
+    inlines = (UserRoleInline,)
     add_fieldsets = (
         (
             None,

--- a/libriscan/biblios/templates/biblios/widgets/read_only_secret_key.html
+++ b/libriscan/biblios/templates/biblios/widgets/read_only_secret_key.html
@@ -1,0 +1,5 @@
+{% load secrets %}
+<div{% include 'django/forms/widgets/attrs.html' %}>
+  {% render_secret_key_as_masked widget.value %}
+  {% if not widget.value %}<input type="{{ widget.type }}" name="{{ widget.name }}">{% endif %}
+</div>

--- a/libriscan/biblios/templatetags/secrets.py
+++ b/libriscan/biblios/templatetags/secrets.py
@@ -1,0 +1,12 @@
+from django.template import Library
+from django.utils.html import format_html
+from django.utils.translation import gettext
+
+register = Library()
+
+
+@register.simple_tag
+def render_secret_key_as_masked(value):
+    if not value:
+        return format_html("<p><strong>{}</strong></p>", gettext("No secret key set."))
+    return format_html("<p>{}</p>", f"{value[:4]}··················")

--- a/libriscan/biblios/widgets.py
+++ b/libriscan/biblios/widgets.py
@@ -1,0 +1,5 @@
+from django.forms import Widget
+
+
+class SecretKeyWidget(Widget):
+    template_name = "biblios/widgets/read_only_secret_key.html"


### PR DESCRIPTION
This change implements some very minor changes to make Admin a little cleaner, and also completely changes the cloud service admin to resolve #407 

- Add additional fields to the Org list display
- Move user roles to inlines on User and Organization (admins can use either interchangeably)
- Minor refactoring of admin.py, no functional impact
- Change cloud service to a standalone admin page
- Add a new widget SecretKeyWidget, along with its template and a new template tag, to present the secret key as a partially-masked read-only value once it's been entered

**Note:**
The problem we were encountering was that by rendering the key as an input field of any kind, we needed to actually provide a value when the user tried to save the Organization record. We couldn't do that without either rendering the key in cleartext on the screen or doing a lot of javascript. This approach only shows an input field if there is no key on the record, and otherwise will show the user the first four characters of the key if it exists. 

This means the user will need to delete the cloud service record entirely if they need to change the key. That's probably acceptable because the only other data points are the service (which is not hard to enter) and the client ID, which will probably need to change anyway when the key does. However, I felt the risk was high that admins would confuse "delete this cloud service" and "delete the entire organization and all its data", so I moved cloud services from an inline on the org to a standalone page to prevent this possibility.

Closes #385 and #407 